### PR TITLE
small fix

### DIFF
--- a/Extras-Addon.lua
+++ b/Extras-Addon.lua
@@ -4417,7 +4417,7 @@ Objets:add_button("Spawn Selected", function()
             ENTITY.SET_ENTITY_ROTATION(spawnedObject, orientationRoll, orientationYaw, playerHeading + orientationPitch, 2, true)  -- Adjust rotation if needed
             --gui.show_message("Preview", "Moved ".. selectedObjectInfo.nom.. " to ".. tostring(spawnX).. ", ".. tostring(spawnY))
             local net_id = NETWORK.OBJ_TO_NET(spawnedObject)
-            NETWORK.SET_NETWORK_ID_EXISTS_ON_ALL_MACHINES(spawnedObject, true)
+            NETWORK.SET_NETWORK_ID_EXISTS_ON_ALL_MACHINES(net_id, true)
             gui.show_message("Object Spawner", "Spawned object "..selectedObjectInfo.nom.." on "..playerName)
             ENTITY.SET_ENTITY_AS_NO_LONGER_NEEDED(spawnedObject)
             table.insert(spawnedObjects, spawnedObject)
@@ -5746,7 +5746,7 @@ script.register_looped("autoGetHangarCargo", function(script)
     if hStock:is_enabled() == true then
         autoGetHangarCargo = not autoGetHangarCargo
         if autoGetHangarCargo then
-            stats.set_bool_masked("MP0_DLC22022PSTAT_BOOL3", true, 9)
+            stats.set_bool_masked("MP"..stats.get_int("MPPLY_LAST_MP_CHAR").."_DLC22022PSTAT_BOOL3", true, 9)
             gui.show_message("Hangar", "Restocking hangar cargo, please wait...")
             sleep(0.5)
         end

--- a/Extras-Addon.lua
+++ b/Extras-Addon.lua
@@ -5753,7 +5753,7 @@ script.register_looped("autoGetHangarCargo", function(script)
     if hStock:is_enabled() == true then
         autoGetHangarCargo = not autoGetHangarCargo
         if autoGetHangarCargo then
-            stats.set_bool_masked(MPX .. "_DLC22022PSTAT_BOOL3", true, 9)
+            stats.set_bool_masked(MPX .. "DLC22022PSTAT_BOOL3", true, 9)
             gui.show_message("Hangar", "Restocking hangar cargo, please wait...")
             sleep(0.5)
         end

--- a/Extras-Addon.lua
+++ b/Extras-Addon.lua
@@ -5742,11 +5742,18 @@ local Hangar = Business:add_tab("Hangar")
 
 hStock = Hangar:add_checkbox("Resupply Hangar Cargo (Looped)")
 script.register_looped("autoGetHangarCargo", function(script)
+  MPX = PI
+        PI = stats.get_int("MPPLY_LAST_MP_CHAR")
+        if PI == 0 then
+            MPX = "MP0_"
+        else
+            MPX = "MP1_"
+        end
     script:yield()
     if hStock:is_enabled() == true then
         autoGetHangarCargo = not autoGetHangarCargo
         if autoGetHangarCargo then
-            stats.set_bool_masked("MP"..stats.get_int("MPPLY_LAST_MP_CHAR").."_DLC22022PSTAT_BOOL3", true, 9)
+            stats.set_bool_masked(MPX .. "_DLC22022PSTAT_BOOL3", true, 9)
             gui.show_message("Hangar", "Restocking hangar cargo, please wait...")
             sleep(0.5)
         end


### PR DESCRIPTION
- Object Spawner: fixed param1 of native SetNetworkIdExistsOnAllMachines()

- Hangar Cargo: using MP0 only works for multiplayer character 01. If you're using a secondary character, this will do nothing so we should get which character the player is using.