### PR TITLE
Update YimActions and TokyoDrift

### DIFF
--- a/Extras-Addon.lua
+++ b/Extras-Addon.lua
@@ -1502,78 +1502,43 @@ Tel:add_imgui(function()
         ImGui.SetClipboardText(coordsString)
     end
 end)
-local YimActions = Pla:add_tab("Samurai's YimActions")
+local Yim_Actions = Pla:add_tab("Samurai's Yim_Actions")
 local anim_index = 0
 local scenario_index = 0
+local npc_index = 0
 local switch = 0
 local filteredAnims = {}
 local filteredScenarios = {}
-local spawned_props = {}
 local searchQuery = ""
 local is_typing = false
+local searchBar = true
+local x = 0
+local counter = 0
 local clumsy = false
 local rod = false
+spawned_entities = {}
+spawned_npcs = {}
+is_playing_anim = false
+is_playing_scenario = false
+disableProps = false
+local disableTooltips = false
+local phoneAnim = false
+local sprintInside = false
+local lockPick = false
 local manualFlags = false
-local disableProps = false
 local controllable = false
 local looped = false
 local upperbody = false
 local freeze = false
-is_playing_anim = false
-is_playing_scenario = false
-script.register_looped("playerID", function(playerID)
-    if NETWORK.NETWORK_IS_SESSION_ACTIVE() then
-        is_online = true
-        onlinePed = PLAYER.GET_PLAYER_PED_SCRIPT_INDEX(PLAYER.PLAYER_ID())
-    else
-        is_online = false
-        spPed = self.get_ped()
-    end
-    if is_online then
-        ped = onlinePed
-    else
-        ped = spPed
-    end
-    playerID:yield()
-end)
-script.register_looped("Ragdoll Loop", function(script)
-    script:yield()
-    if clumsy then
-        script:sleep(100)
-        rod = false
-        if PED.IS_PED_RAGDOLL(ped) then
-            script:sleep(2500)
-            return
-        end
-        PED.SET_PED_RAGDOLL_ON_COLLISION(ped, true)
-    elseif rod then
-        script:sleep(100)
-        clumsy = false
-        if PAD.IS_CONTROL_PRESSED(0, 252) then
-            PED.SET_PED_TO_RAGDOLL(ped, 1500, 0, 0, false)
-        end
-    end
-    script:yield()
-end)
-script.register_looped("animation hotkey", function(script)
-    script:yield()
-    if is_playing_anim then
-        if PAD.IS_CONTROL_PRESSED(0, 256) then
-            if PED.IS_PED_IN_ANY_VEHICLE(ped, false) then
-                cleanup()
-                is_playing_anim = false
-            else
-                cleanup()
-                is_playing_anim = false
-                local current_coords = ENTITY.GET_ENTITY_COORDS(ped)
-                ENTITY.SET_ENTITY_COORDS_NO_OFFSET(ped, current_coords.x, current_coords.y, current_coords.z, true, false, false)
-            end
-        end
-    end
-end)
-script.register_looped("disable game input", function()
+local usePlayKey = false
+script.register_looped("game input", function()
         if is_typing then
             PAD.DISABLE_ALL_CONTROL_ACTIONS(0)
+        end
+        if PAD.IS_USING_KEYBOARD_AND_MOUSE() then
+            stopButton = "[G]"
+        else
+            stopButton = "[DPAD LEFT]"
         end
 end)
 local function updatefilteredAnims()
@@ -1595,18 +1560,22 @@ local function displayFilteredAnims()
     end
     anim_index, used = ImGui.ListBox("##animlistbox", anim_index, animNames, #filteredAnims)
 end
-local function Button(text, color, hovercolor, activecolor)
-    ImGui.PushStyleColor(ImGuiCol.Button, color[1], color[2], color[3], color[4])
-    ImGui.PushStyleColor(ImGuiCol.ButtonHovered, hovercolor[1], hovercolor[2], hovercolor[3], hovercolor[4])
-    ImGui.PushStyleColor(ImGuiCol.ButtonActive, activecolor[1], activecolor[2], activecolor[3], activecolor[4])
-    local retval = ImGui.Button(text)
-    ImGui.PopStyleColor()
-    return retval
+local function updateNpcs()
+    filteredNpcs = {}
+    for _, npc in ipairs(npcList) do
+            table.insert(filteredNpcs, npc)
+    end
+    table.sort(filteredNpcs, function(a, b)
+        return a.name < b.name
+    end)
 end
-local function busyspinner(text, type)
-    HUD.BEGIN_TEXT_COMMAND_BUSYSPINNER_ON("STRING")
-    HUD.ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME(text)
-    HUD.END_TEXT_COMMAND_BUSYSPINNER_ON(type)
+local function displayNpcs()
+    updateNpcs()
+    local npcNames = {}
+    for _, npc in ipairs(filteredNpcs) do
+        table.insert(npcNames, npc.name)
+    end
+    npc_index, used = ImGui.Combo("##npcList", npc_index, npcNames, #filteredNpcs)
 end
 local function setmanualflag()
     if looped then
@@ -1631,35 +1600,13 @@ local function setmanualflag()
     end
     flag = flag_loop + flag_freeze + flag_upperbody + flag_control
 end
-local function helpmarker(text)
-    ImGui.SameLine()
-    ImGui.TextDisabled("(?)")
-    if ImGui.IsItemHovered() then
-        ImGui.SetNextWindowBgAlpha(0.75)
-        ImGui.BeginTooltip()
-        ImGui.PushTextWrapPos(ImGui.GetFontSize() * 20)
-        ImGui.TextWrapped(text)
-        ImGui.PopTextWrapPos()
-        ImGui.EndTooltip()
-	end
-end
-local function widgetToolTip(text)
-    if ImGui.IsItemHovered() then
-        ImGui.SetNextWindowBgAlpha(0.75)
-        ImGui.BeginTooltip()
-        ImGui.PushTextWrapPos(ImGui.GetFontSize() * 20)
-        ImGui.TextWrapped(text)
-        ImGui.PopTextWrapPos()
-        ImGui.EndTooltip()
-	end
-end
 local function setdrunk()
     script.run_in_fiber(function()
         while not STREAMING.HAS_CLIP_SET_LOADED("MOVE_M@DRUNK@VERYDRUNK") do
             STREAMING.REQUEST_CLIP_SET("MOVE_M@DRUNK@VERYDRUNK")
             coroutine.yield()
         end
-        PED.SET_PED_MOVEMENT_CLIPSET(ped, "MOVE_M@DRUNK@VERYDRUNK", 1.0)
+        PED.SET_PED_MOVEMENT_CLIPSET(self.get_ped(), "MOVE_M@DRUNK@VERYDRUNK", 1.0)
     end)
 end
 local function sethoe()
@@ -1668,7 +1615,7 @@ local function sethoe()
             STREAMING.REQUEST_CLIP_SET("move_f@maneater")
             coroutine.yield()
         end
-        PED.SET_PED_MOVEMENT_CLIPSET(ped, "move_f@maneater", 1.0)
+        PED.SET_PED_MOVEMENT_CLIPSET(self.get_ped(), "move_f@maneater", 1.0)
     end)
 end
 local function setcrouched()
@@ -1677,7 +1624,7 @@ local function setcrouched()
             STREAMING.REQUEST_CLIP_SET("move_ped_crouched")
             coroutine.yield()
         end
-        PED.SET_PED_MOVEMENT_CLIPSET(ped, "move_ped_crouched", 0.3)
+        PED.SET_PED_MOVEMENT_CLIPSET(self.get_ped(), "move_ped_crouched", 0.3)
     end)
 end
 local function setlester()
@@ -1686,7 +1633,7 @@ local function setlester()
             STREAMING.REQUEST_CLIP_SET("move_heist_lester")
             coroutine.yield()
         end
-        PED.SET_PED_MOVEMENT_CLIPSET(ped, "move_heist_lester", 0.4)
+        PED.SET_PED_MOVEMENT_CLIPSET(self.get_ped(), "move_heist_lester", 0.4)
     end)
 end
 local function setballistic()
@@ -1695,314 +1642,407 @@ local function setballistic()
             STREAMING.REQUEST_CLIP_SET("anim_group_move_ballistic")
             coroutine.yield()
         end
-        PED.SET_PED_MOVEMENT_CLIPSET(ped, "anim_group_move_ballistic", 1)
+        PED.SET_PED_MOVEMENT_CLIPSET(self.get_ped(), "anim_group_move_ballistic", 1)           
     end)
 end
-YimActions:add_imgui(function()
-    ImGui.Text("Search:")
-    ImGui.PushItemWidth(350)
-    searchQuery, used = ImGui.InputText("", searchQuery, 32)
-    if ImGui.IsItemActive() then
-        is_typing = true
+function resetCheckBoxes()
+    disableTooltips = false
+    phoneAnim = false
+    lockPick = false
+    sprintInside = false
+    clumsy = false
+    rod = false
+    disableProps = false
+    manualFlags = false
+    controllable = false
+    looped = false
+    upperbody = false
+    freeze = false
+    usePlayKey = false
+end
+script.register_looped("onlineStatus", function(onlineStatus)
+    if NETWORK.NETWORK_IS_SESSION_ACTIVE() then
+        is_online = true
     else
-        is_typing = false
+        is_online = false
     end
-    ImGui.BeginTabBar("Samurai's YimActions", ImGuiTabBarFlags.None)
+    onlineStatus:yield()
+end)
+script.register_looped("Ragdoll Loop", function(script)
+    script:yield()
+    if clumsy then
+        if PED.IS_PED_RAGDOLL(self.get_ped()) then
+            script:sleep(2500)
+            return
+        end
+        PED.SET_PED_RAGDOLL_ON_COLLISION(self.get_ped(), true)
+    elseif rod then
+        if PAD.IS_CONTROL_PRESSED(0, 252) then
+            PED.SET_PED_TO_RAGDOLL(self.get_ped(), 1500, 0, 0, false)
+        end
+    end
+    script:yield()
+end)
+script.register_looped("follow ped", function(follow)
+    for k, v in ipairs(spawned_npcs) do
+        if ENTITY.DOES_ENTITY_EXIST(v) then
+            if ENTITY.IS_ENTITY_DEAD(v) then
+                follow:sleep(2000)
+                PED.RESURRECT_PED(v)
+                TASK.CLEAR_PED_TASKS_IMMEDIATELY(v)
+                TASK.TASK_FOLLOW_TO_OFFSET_OF_ENTITY(v, self.get_ped(), 0.5, 0.5, 0.0, -1, -1, 1.4, true)
+                PED.SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(v, true)
+            elseif PED.IS_PED_IN_ANY_VEHICLE(self.get_ped(), true) and not PED.IS_PED_SITTING_IN_ANY_VEHICLE(v) then
+                veh = PED.GET_VEHICLE_PED_IS_USING(self.get_ped())
+                if VEHICLE.IS_VEHICLE_SEAT_FREE(veh, 0, 0) then
+                    seat = 0
+                else
+                    seat = tostring(k)
+                end
+                TASK.CLEAR_PED_TASKS_IMMEDIATELY(v)
+                TASK.TASK_ENTER_VEHICLE(v, veh, 20000, seat, 2.0, 16, 0)
+                follow:sleep(2000)
+            elseif PED.IS_PED_SITTING_IN_ANY_VEHICLE(v) and not PED.IS_PED_IN_ANY_VEHICLE(self.get_ped(), false) then
+                TASK.CLEAR_PED_TASKS(v)
+                TASK.TASK_LEAVE_VEHICLE(v, veh, 0)
+                TASK.TASK_FOLLOW_TO_OFFSET_OF_ENTITY(v, self.get_ped(), 0.5, 0.5, 0.0, -1, -1, 1.4, true)
+                PED.SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(v, true)
+            end
+        end
+        follow:yield()
+    end
+    
+    if VEHICLE.IS_THIS_MODEL_A_BIKE(ENTITY.GET_ENTITY_MODEL(veh)) then
+        PED.SET_PED_CONFIG_FLAG(self.get_ped(), 424, true)
+    end
+end)
+Yim_Actions:add_imgui(function()
+    if searchBar then
+        ImGui.PushItemWidth(270)
+        searchQuery, used = ImGui.InputTextWithHint("##searchBar", "Search", searchQuery, 32)
+        if ImGui.IsItemActive() then
+            is_typing = true
+        else
+            is_typing = false
+        end
+    end
+    ImGui.BeginTabBar("Samurai's Yim_Actions", ImGuiTabBarFlags.None)
     if ImGui.BeginTabItem("Animations") then
-        ImGui.PushItemWidth(350)
+        ImGui.PushItemWidth(345)
         displayFilteredAnims()
+        info = filteredAnims[anim_index + 1]
         ImGui.Separator()
         manualFlags, used = ImGui.Checkbox("Edit Flags", manualFlags, true)
-        helpmarker("Allows you to customize how the animation plays.\nExample: if an animation is set to loop but you want it to freeze, activate this then choose your desired settings.")
+        helpmarker(false, "Allows you to customize how the animation plays.\nExample: if an animation is set to loop but you want it to freeze, activate this then choose your desired settings.")
         ImGui.SameLine()
         disableProps, used = ImGui.Checkbox("Disable Props", disableProps, true)
-        helpmarker("Choose whether to play animations with props or not. Check or Un-check this before playing the animation.")
+        helpmarker(false, "Choose whether to play animations with props or not. Check or Un-check this before playing the animation.")
         if manualFlags then
             ImGui.Separator()
             controllable, used = ImGui.Checkbox("Allow Control", controllable, true)
-            helpmarker("Allows you to keep control of your character and/or vehicle. If paired with 'Upper Body Only', you can play animations and walk/run/drive around.")
+            helpmarker(false, "Allows you to keep control of your character and/or vehicle. If paired with 'Upper Body Only', you can play animations and walk/run/drive around.")
             ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine()
             looped, used = ImGui.Checkbox("Loop", looped, true)
-            helpmarker("Plays the animation forever until you manually stop it.")
+            helpmarker(false, "Plays the animation forever until you manually stop it.")
             upperbody, used = ImGui.Checkbox("Upper Body Only", upperbody, true)
-            helpmarker("Only plays the animation on you character's upperbody (from the waist up).")
+            helpmarker(false, "Only plays the animation on you character's upperbody (from the waist up).")
             ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine()
             freeze, used = ImGui.Checkbox("Freeze", freeze, true)
-            helpmarker("Freezes the animation at the very last frame. Useful for ragdoll/sleeping/dead animations.")
+            helpmarker(false, "Freezes the animation at the very last frame. Useful for ragdoll/sleeping/dead animations.")
         end
-        info = filteredAnims[anim_index + 1]
         function cleanup()
             script.run_in_fiber(function()
-                TASK.CLEAR_PED_TASKS(ped)
-                ENTITY.DELETE_ENTITY(prop1)
-                ENTITY.DELETE_ENTITY(prop2)
+                TASK.CLEAR_PED_TASKS(self.get_ped())
                 GRAPHICS.STOP_PARTICLE_FX_LOOPED(loopedFX)
                 STREAMING.REMOVE_ANIM_DICT(info.dict)
                 STREAMING.REMOVE_NAMED_PTFX_ASSET(info.ptfxdict)
+                if ENTITY.DOES_ENTITY_EXIST(sexPed) then
+                    PED.DELETE_PED(sexPed)
+                end
+                if spawned_entities[1] ~= nil then
+                    for _, v in ipairs(spawned_entities) do
+                        script.run_in_fiber(function(script)
+                            if ENTITY.DOES_ENTITY_EXIST(v) then
+                                ENTITY.SET_ENTITY_AS_MISSION_ENTITY(v)
+                                script:sleep(100)
+                                ENTITY.DELETE_ENTITY(v)
+                            end
+                        end)
+                    end
+                end
             end)
         end
-        if ImGui.Button("   Play    ") then
-            local coords = ENTITY.GET_ENTITY_COORDS(ped, false)
-            local heading = ENTITY.GET_ENTITY_HEADING(ped)
-            local forwardX = ENTITY.GET_ENTITY_FORWARD_X(ped)
-            local forwardY = ENTITY.GET_ENTITY_FORWARD_Y(ped)
-            local boneIndex = PED.GET_PED_BONE_INDEX(ped, info.boneID)
-            local bonecoords = PED.GET_PED_BONE_COORDS(ped, info.boneID)
+        if ImGui.Button("   Play   ") then
+            local coords = ENTITY.GET_ENTITY_COORDS(self.get_ped(), false)
+            local heading = ENTITY.GET_ENTITY_HEADING(self.get_ped())
+            local forwardX = ENTITY.GET_ENTITY_FORWARD_X(self.get_ped())
+            local forwardY = ENTITY.GET_ENTITY_FORWARD_Y(self.get_ped())
+            local boneIndex = PED.GET_PED_BONE_INDEX(self.get_ped(), info.boneID)
+            local bonecoords = PED.GET_PED_BONE_COORDS(self.get_ped(), info.boneID)
             if manualFlags then
                 setmanualflag()
             else
                 flag = info.flag
             end
-            if info.type == 1 then
-                cleanup()
-                script.run_in_fiber(function()
-                    if not disableProps then
-                        while not STREAMING.HAS_MODEL_LOADED(info.prop1) do
-                            STREAMING.REQUEST_MODEL(info.prop1)
-                            coroutine.yield()
-                        end
-                        prop1 = OBJECT.CREATE_OBJECT(info.prop1, 0.0, 0.0, 0.0, true, true, true)
-                        table.insert(spawned_props, prop1)
-                        ENTITY.ATTACH_ENTITY_TO_ENTITY(prop1, ped, boneIndex, info.posx, info.posy, info.posz, info.rotx, info.roty, info.rotz, false, false, false, false, 2, true, 1)
-                    end
-                    while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict) do
-                        STREAMING.REQUEST_ANIM_DICT(info.dict)
-                        coroutine.yield()
-                    end
-                    TASK.TASK_PLAY_ANIM(ped, info.dict, info.anim, 4.0, -4.0, -1, flag, 1.0, false, false, false)
-                    is_playing_anim = true
-                end)
-            elseif info.type == 2 then
-                cleanup()
-                script.run_in_fiber(function(type2)
-                    while not STREAMING.HAS_NAMED_PTFX_ASSET_LOADED(info.ptfxdict) do
-                        STREAMING.REQUEST_NAMED_PTFX_ASSET(info.ptfxdict)
-                        coroutine.yield()
-                    end
-                    while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict) do
-                        STREAMING.REQUEST_ANIM_DICT(info.dict)
-                        coroutine.yield()
-                    end
-                    TASK.TASK_PLAY_ANIM(ped, info.dict, info.anim, 4.0, -4.0, -1, flag, 0, false, false, false)
-                    is_playing_anim = true
-                    type2:sleep(info.ptfxdelay)
-                    GRAPHICS.USE_PARTICLE_FX_ASSET(info.ptfxdict)
-                    loopedFX = GRAPHICS.START_NETWORKED_PARTICLE_FX_LOOPED_ON_ENTITY_BONE(info.ptfxname, ped, info.ptfxOffx, info.ptfxOffy, info.ptfxOffz, info.ptfxrotx, info.ptfxroty, info.ptfxrotz, boneIndex, info.ptfxscale, false, false, false, 0, 0, 0, 0)
-                end)
-            elseif info.type == 3 then
-                cleanup()
-                script.run_in_fiber(function()
-                    if not disableProps then
-                        while not STREAMING.HAS_MODEL_LOADED(info.prop1) do
-                            STREAMING.REQUEST_MODEL(info.prop1)
-                            coroutine.yield()
-                        end
-                        prop1 = OBJECT.CREATE_OBJECT(info.prop1, coords.x + forwardX /1.7, coords.y + forwardY /1.7, coords.z, true, true, false)
-                        table.insert(spawned_props, prop1)
-                        ENTITY.SET_ENTITY_HEADING(prop1, heading + info.rotz)
-                        OBJECT.PLACE_OBJECT_ON_GROUND_PROPERLY(prop1)
-                    end
-                    while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict) do
-                        STREAMING.REQUEST_ANIM_DICT(info.dict)
-                        coroutine.yield()
-                    end
-                    TASK.TASK_PLAY_ANIM(ped, info.dict, info.anim, 4.0, -4.0, -1, flag, 1.0, false, false, false)
-                    is_playing_anim = true
-                end)
-            elseif info.type == 4 then
-                cleanup()
-                script.run_in_fiber(function(type4)
-                    if not disableProps then
-                        while not STREAMING.HAS_MODEL_LOADED(info.prop1) do
-                            STREAMING.REQUEST_MODEL(info.prop1)
-                            coroutine.yield()
-                        end
-                        prop1 = OBJECT.CREATE_OBJECT(info.prop1, 0.0, 0.0, 0.0, true, true, false)
-                        table.insert(spawned_props, prop1)
-                        ENTITY.SET_ENTITY_COORDS(prop1, bonecoords.x + info.posx, bonecoords.y + info.posy, bonecoords.z + info.posz)
-                        type4:sleep(20)
-                        OBJECT.PLACE_OBJECT_ON_GROUND_PROPERLY(prop1)
-                        ENTITY.SET_ENTITY_COLLISION(prop1, info.propColl, info.propColl)
-                    end
-                    while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict) do
-                        STREAMING.REQUEST_ANIM_DICT(info.dict)
-                        coroutine.yield()
-                    end
-                    TASK.TASK_PLAY_ANIM(ped, info.dict, info.anim, 4.0, -4.0, -1, flag, 1.0, false, false, false)
-                    is_playing_anim = true
-                end)
-            elseif info.type == 5 then
-                cleanup()
-                script.run_in_fiber(function(type5)
-                    while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict) do
-                        STREAMING.REQUEST_ANIM_DICT(info.dict)
-                        coroutine.yield()
-                    end
-                    TASK.TASK_PLAY_ANIM(ped, info.dict, info.anim, 4.0, -4.0, -1, flag, 0.0, false, false, false)
-                    if not disableProps then
-                        while not STREAMING.HAS_MODEL_LOADED(info.prop1) do
-                            STREAMING.REQUEST_MODEL(info.prop1)
-                            coroutine.yield()
-                        end
-                        prop1 = OBJECT.CREATE_OBJECT(info.prop1, 0.0, 0.0, 0.0, true, true, false)
-                        table.insert(spawned_props, prop1)
-                        ENTITY.ATTACH_ENTITY_TO_ENTITY(prop1, ped, boneIndex, info.posx, info.posy, info.posz, info.rotx, info.roty, info.rotz, false, false, false, false, 2, true, 1)
-                        type5:sleep(50)
-                        while not STREAMING.HAS_NAMED_PTFX_ASSET_LOADED(info.ptfxdict) do
-                            STREAMING.REQUEST_NAMED_PTFX_ASSET(info.ptfxdict)
-                            coroutine.yield()
-                        end
-                        type5:sleep(info.ptfxdelay)
-                        GRAPHICS.USE_PARTICLE_FX_ASSET(info.ptfxdict)
-                        loopedFX = GRAPHICS.START_NETWORKED_PARTICLE_FX_LOOPED_ON_ENTITY(info.ptfxname, prop1, info.ptfxOffx, info.ptfxOffy, info.ptfxOffz, info.ptfxrotx, info.ptfxroty, info.ptfxrotz, info.ptfxscale, false, false, false, 0, 0, 0, 0)
-                    end
-                    is_playing_anim = true
-                end)
-            elseif info.type == 6 then
-                    cleanup()
-                    script.run_in_fiber(function()
-                        if not disableProps then
-                            while not STREAMING.HAS_MODEL_LOADED(info.prop1) do
-                                STREAMING.REQUEST_MODEL(info.prop1)
-                                coroutine.yield()
-                            end
-                            prop1 = OBJECT.CREATE_OBJECT(info.prop1, 0.0, 0.0, 0.0, true, true, false)
-                            table.insert(spawned_props, prop1)
-                            ENTITY.ATTACH_ENTITY_TO_ENTITY(prop1, ped, boneIndex, info.posx, info.posy, info.posz, info.rotx, info.roty, info.rotz, false, false, false, false, 2, true, 1)
-                            while not STREAMING.HAS_MODEL_LOADED(info.prop2) do
-                                STREAMING.REQUEST_MODEL(info.prop2)
-                                coroutine.yield()
-                            end
-                            prop2 = OBJECT.CREATE_OBJECT(info.prop2, 0.0, 0.0, 0.0, true, true, false)
-                            table.insert(spawned_props, prop2)
-                            ENTITY.ATTACH_ENTITY_TO_ENTITY(prop2, ped, PED.GET_PED_BONE_INDEX(ped, info.bone2), info.posx2, info.posy2, info.posz2, info.rotx2, info.roty2, info.rotz2, false, false, false, false, 2, true, 1)
-                        end
-                        while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict) do
-                            STREAMING.REQUEST_ANIM_DICT(info.dict)
-                            coroutine.yield()
-                        end
-                        TASK.TASK_PLAY_ANIM(ped, info.dict, info.anim, 4.0, -4.0, -1, flag, 1.0, false, false, false)
-                        is_playing_anim = true
-                    end)
-            else
-                cleanup()
-                script.run_in_fiber(function()
-                    while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict) do
-                        STREAMING.REQUEST_ANIM_DICT(info.dict)
-                        coroutine.yield()
-                    end
-                    TASK.TASK_PLAY_ANIM(ped, info.dict, info.anim, 4.0, -4.0, -1, flag, 0.0, false, false, false)
-                    is_playing_anim = true
-                end)
-            end
+            playSelected(self.get_ped(), sexPed, boneIndex, coords, heading, forwardX, forwardY, bonecoords)
+            is_playing_anim = true
         end
         ImGui.SameLine()
-        if ImGui.Button("   Stop    ") then
-            if PED.IS_PED_IN_ANY_VEHICLE(ped, false) then
+        if ImGui.Button("   Stop   ") then
+            if PED.IS_PED_IN_ANY_VEHICLE(self.get_ped(), false) then
                 cleanup()
-                is_playing_anim = false
+                local veh = PED.GET_VEHICLE_PED_IS_USING(self.get_ped())
+                PED.SET_PED_INTO_VEHICLE(self.get_ped(), veh, -1)
             else
                 cleanup()
-                is_playing_anim = false
-                local current_coords = ENTITY.GET_ENTITY_COORDS(ped)   
-                ENTITY.SET_ENTITY_COORDS_NO_OFFSET(ped, current_coords.x, current_coords.y, current_coords.z, true, false, false)
+                local current_coords = ENTITY.GET_ENTITY_COORDS(self.get_ped())
+                ENTITY.SET_ENTITY_COORDS_NO_OFFSET(self.get_ped(), current_coords.x, current_coords.y, current_coords.z, true, false, false)
             end
+            is_playing_anim = false
         end
-        widgetToolTip("TIP: You can also stop animations by pressing [Delete] on keyboard or [X] on controller.")
+        widgetToolTip(false, "TIP: You can also stop animations by pressing [G] on keyboard or [DPAD LEFT] on controller.")
         ImGui.SameLine()
-        if Button("Force Detach Props", {1, 0, 0, 1}, {1, 0, 0, 0.7}, {1, 0, 0, 0.5}) then
-            for k, v in ipairs(spawned_props) do
-                if is_playing_anim then
+        local errCol = {}
+        if spawned_entities[1] ~= nil then
+            errCol = {104, 247, 114, 0.2}
+        else
+            errCol = {225, 0, 0, 0.5}
+        end
+        if Button("Remove Attachments", {104, 247, 114, 0.6}, {104, 247, 114, 0.5}, errCol) then
+            if spawned_entities[1] ~= nil then
+                for k, v in ipairs(spawned_entities) do
                     script.run_in_fiber(function()
                         if ENTITY.DOES_ENTITY_EXIST(v) then
                             ENTITY.DETACH_ENTITY(v)
                             ENTITY.SET_ENTITY_AS_NO_LONGER_NEEDED(v)
-                            TASK.CLEAR_PED_TASKS(ped)
+                            TASK.CLEAR_PED_TASKS(self.get_ped())
+                            TASK.CLEAR_PED_TASKS(npc)
+                            TASK.CLEAR_PED_TASKS(sexPed)
+                            TASK.CLEAR_PED_TASKS(sexPed2)
                             is_playing_anim = false
-                            table.remove(spawned_props, k)
                         end
                     end)
+                    table.remove(spawned_entities, k)
                 end
+            else
+                gui.show_error("Yim_Actions", "There are no attachments to remove!")
             end
         end
-        widgetToolTip("Some props may become stuck if the animation gets unexpectedly interrupted. Use this button to get rid of them.")
-        event.register_handler(menu_event.ScriptsReloaded, function()
-            PED.RESET_PED_MOVEMENT_CLIPSET(ped, 0.0)
-            PED.SET_PED_RAGDOLL_ON_COLLISION(ped, false)
-            if is_playing_anim then
-                GRAPHICS.STOP_PARTICLE_FX_LOOPED(loopedFX)
-                ENTITY.DELETE_ENTITY(prop1)
-                ENTITY.SET_ENTITY_AS_NO_LONGER_NEEDED(prop1)
-                ENTITY.DELETE_ENTITY(prop2)
-                ENTITY.SET_ENTITY_AS_NO_LONGER_NEEDED(prop2)
-                TASK.CLEAR_PED_TASKS_IMMEDIATELY(ped)
-                STREAMING.REMOVE_NAMED_PTFX_ASSET(info.ptfxdict)
-                STREAMING.REMOVE_ANIM_DICT(info.dict)
-            -- //fix player clipping through the ground after ending low-positioned anims//
-                local current_coords = ENTITY.GET_ENTITY_COORDS(ped)
-                if PED.IS_PED_IN_ANY_VEHICLE(ped, false) then
-                    PED.SET_PED_COORDS_KEEP_VEHICLE(ped, current_coords.x, current_coords.y, current_coords.z)
-                else
-                    ENTITY.SET_ENTITY_COORDS_NO_OFFSET(ped, current_coords.x, current_coords.y, current_coords.z, true, false, false)
-                end
-                is_playing_anim = false
-            end
-        end)
-        event.register_handler(menu_event.MenuUnloaded, function()
-            PED.RESET_PED_MOVEMENT_CLIPSET(ped, 0.0)
-            PED.SET_PED_RAGDOLL_ON_COLLISION(ped, false)
-            if is_playing_anim then
-                GRAPHICS.STOP_PARTICLE_FX_LOOPED(loopedFX)
-                ENTITY.DELETE_ENTITY(prop1)
-                ENTITY.SET_ENTITY_AS_NO_LONGER_NEEDED(prop1)
-                ENTITY.DELETE_ENTITY(prop2)
-                ENTITY.SET_ENTITY_AS_NO_LONGER_NEEDED(prop2)
-                TASK.CLEAR_PED_TASKS_IMMEDIATELY(ped)
-                STREAMING.REMOVE_NAMED_PTFX_ASSET(info.ptfxdict)
-                STREAMING.REMOVE_ANIM_DICT(info.dict)
-            -- //fix player clipping through the ground after ending low-positioned anims//
-                local current_coords = ENTITY.GET_ENTITY_COORDS(ped)
-                if PED.IS_PED_IN_ANY_VEHICLE(ped, false) then
-                    PED.SET_PED_COORDS_KEEP_VEHICLE(ped, current_coords.x, current_coords.y, current_coords.z)
-                else
-                    ENTITY.SET_ENTITY_COORDS_NO_OFFSET(ped, current_coords.x, current_coords.y, current_coords.z, true, false, false)
-                end
-                is_playing_anim = false
-            end
-        end)
+        widgetToolTip(false, "Detaches any attached or stuck props/peds.\n(Only works on attachments from this script)")
         ImGui.Separator()
         ImGui.Text("Ragdoll Options:")
         ImGui.Spacing()
         clumsy, used = ImGui.Checkbox("Clumsy", clumsy, true)
-        helpmarker("Makes You Ragdoll When You Collide With Any Object.\n(Doesn't work with Ragdoll On Demand)")
-        ImGui.SameLine()
+        if clumsy then
+            rod = false
+        end
+        widgetToolTip(false, "Makes You Ragdoll When You Collide With Any Object.\n(Doesn't work with Ragdoll On Demand)")
+        ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine()
         rod, used = ImGui.Checkbox("Ragdoll On Demand", rod, true)
-        helpmarker("Press [X] On Keyboard or [LT] On Controller To Instantly Ragdoll. The Longer You Hold The Button, The Longer You Stay On The Ground.\n(Doesn't work with Clumsy)")
+        if rod then
+            clumsy = false
+        end
+        widgetToolTip(false, "Press [X] On Keyboard or [LT] On Controller To Instantly Ragdoll. The Longer You Hold The Button, The Longer You Stay On The Ground.\n(Doesn't work with Clumsy)")
         ImGui.Spacing()
         ImGui.Text("Movement Options:")
         ImGui.Spacing()
         local isChanged = false
         switch, isChanged = ImGui.RadioButton("Normal", switch, 0)
         if isChanged then
-            PED.RESET_PED_MOVEMENT_CLIPSET(ped, 0.0)
+            PED.RESET_PED_MOVEMENT_CLIPSET(self.get_ped(), 0.0)
             isChanged = false
         end
-        ImGui.SameLine()
+        ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine()
         switch, isChanged = ImGui.RadioButton("Drunk", switch, 1)
-        widgetToolTip("Works Great With Ragdoll Options.")
+        widgetToolTip(false, "Works Great With Ragdoll Options.")
         if isChanged then setdrunk() end
-        ImGui.SameLine()
+        ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine()
         switch, isChanged = ImGui.RadioButton("Hoe", switch, 2)
         if isChanged then sethoe() end
         switch, isChanged = ImGui.RadioButton("Crouch", switch, 3)
-        widgetToolTip("You can pair this with the default stealth action [LEFT CTRL].")
+        widgetToolTip(false, "You can pair this with the default stealth action [LEFT CTRL].")
         if isChanged then setcrouched() end
-        ImGui.SameLine()
+        ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine()
         switch, isChanged = ImGui.RadioButton("Lester", switch, 4)
         if isChanged then setlester() end
-        ImGui.SameLine()
+        ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine()
         switch, isChanged = ImGui.RadioButton("Heavy", switch, 5)
         if isChanged then setballistic() end
+        ImGui.Separator()
+        ImGui.Text("Play Animations On NPCs:")
+        ImGui.SameLine()
+        coloredText("[Work In Progress]", {247, 185, 104, 0.78})
+        ImGui.PushItemWidth(200)
+        displayNpcs()
+        ImGui.PopItemWidth()
+        ImGui.SameLine()
+        local npcData = filteredNpcs[npc_index + 1]
+        function cleanupNPC()
+            script.run_in_fiber(function()
+                for _, v in ipairs(spawned_npcs) do
+                    TASK.CLEAR_PED_TASKS(v)
+                    TASK.TASK_FOLLOW_TO_OFFSET_OF_ENTITY(v, self.get_ped(), 0.5, 0.5, 0.0, -1, -1, 1.4, true)
+                    PED.SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(v, true)
+                end
+                if spawned_entities[1] ~= nil then
+                    for _, b in ipairs(spawned_entities) do
+                        script.run_in_fiber(function(script)
+                            if ENTITY.DOES_ENTITY_EXIST(b) then
+                                ENTITY.SET_ENTITY_AS_MISSION_ENTITY(b)
+                                script:sleep(100)
+                                ENTITY.DELETE_ENTITY(b)
+                            end
+                        end)
+                    end
+                end
+                if ENTITY.DOES_ENTITY_EXIST(sexPed2) then
+                    PED.DELETE_PED(sexPed2)
+                end
+                GRAPHICS.STOP_PARTICLE_FX_LOOPED(loopedFX2)
+                STREAMING.REMOVE_ANIM_DICT(info.dict)
+                STREAMING.REMOVE_NAMED_PTFX_ASSET(info.ptfxdict)
+            end)
+        end
+        if ImGui.Button("Spawn") then
+            script.run_in_fiber(function(script)
+                local pedCoords = ENTITY.GET_ENTITY_COORDS(self.get_ped(), false)
+                local pedHeading = ENTITY.GET_ENTITY_HEADING(self.get_ped())
+                local pedForwardX = ENTITY.GET_ENTITY_FORWARD_X(self.get_ped())
+                local pedForwardY = ENTITY.GET_ENTITY_FORWARD_Y(self.get_ped())
+                while not STREAMING.HAS_MODEL_LOADED(npcData.hash) do
+                    STREAMING.REQUEST_MODEL(npcData.hash)
+                    coroutine.yield()
+                end
+                npc = PED.CREATE_PED(npcData.group, npcData.hash, 0.0, 0.0, 0.0, 0.0, true, false)
+                ENTITY.SET_ENTITY_INVINCIBLE(npc, true)
+                ENTITY.SET_ENTITY_COORDS_NO_OFFSET(npc, pedCoords.x + pedForwardX * 1.4, pedCoords.y + pedForwardY * 1.4, pedCoords.z, true, false, false)
+                ENTITY.SET_ENTITY_HEADING(npc, pedHeading - 180)
+                table.insert(spawned_npcs, npc)
+                npcNetID2 = NETWORK.NETWORK_GET_NETWORK_ID_FROM_ENTITY(npc)
+                RequestControl(npc, npcNetID2, 250)
+                script:sleep(500)
+                entToNet(npc, npcNetID2)
+                TASK.TASK_FOLLOW_TO_OFFSET_OF_ENTITY(npc, self.get_ped(), 0.5, 0.5, 0.0, -1, -1, 1.4, true)
+                PED.SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(npc, true)
+            end)
+        end
+        ImGui.SameLine()
+        if ImGui.Button("Delete") then
+            cleanupNPC()
+            script.run_in_fiber(function()
+                for k, v in ipairs(spawned_npcs) do
+                    ENTITY.DELETE_ENTITY(v)
+                    table.remove(spawned_npcs, k)
+                end
+            end)
+        end
+        if ImGui.Button(" Play On NPC ") then
+            if spawned_npcs[1] ~= nil then
+                for _, v in ipairs(spawned_npcs) do
+                    if ENTITY.DOES_ENTITY_EXIST(v) then
+                        local npcCoords = ENTITY.GET_ENTITY_COORDS(v, false)
+                        local npcHeading = ENTITY.GET_ENTITY_HEADING(v)
+                        local npcForwardX = ENTITY.GET_ENTITY_FORWARD_X(v)
+                        local npcForwardY = ENTITY.GET_ENTITY_FORWARD_Y(v)
+                        local npcBoneIndex = PED.GET_PED_BONE_INDEX(v, info.boneID)
+                        local npcBboneCoords = PED.GET_PED_BONE_COORDS(v, info.boneID)
+                        if manualFlags then
+                            setmanualflag()
+                        else
+                            flag = info.flag
+                        end
+                        playSelected(v, sexPed2, npcBoneIndex, npcCoords, npcHeading, npcForwardX, npcForwardY, npcBboneCoords)
+                    end
+                end
+            else
+                gui.show_error("Yim_Actions", "Spawn an NPC first!")
+            end
+        end
+        ImGui.SameLine()
+        if ImGui.Button("Stop NPC") then
+            cleanupNPC()
+            for _, v in ipairs(spawned_npcs) do
+                script.run_in_fiber(function()
+                    TASK.TASK_FOLLOW_TO_OFFSET_OF_ENTITY(v, self.get_ped(), 0.5, 0.5, 0.0, -1, -1, 1.4, true)
+                    PED.SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(v, true)
+                    if PED.IS_PED_IN_ANY_VEHICLE(v, false) then
+                        local veh = PED.GET_VEHICLE_PED_IS_USING(self.get_ped())
+                        PED.SET_PED_INTO_VEHICLE(v, veh, 0)
+                        PED.SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(v, true)
+                    end
+                end)
+            end
+        end
+        event.register_handler(menu_event.ScriptsReloaded, function()
+            PED.RESET_PED_MOVEMENT_CLIPSET(self.get_ped(), 0.0)
+            PED.SET_PED_RAGDOLL_ON_COLLISION(self.get_ped(), false)
+            if is_playing_anim then
+                TASK.CLEAR_PED_TASKS_IMMEDIATELY(self.get_ped())
+                GRAPHICS.STOP_PARTICLE_FX_LOOPED(loopedFX)
+                STREAMING.REMOVE_NAMED_PTFX_ASSET(info.ptfxdict)
+                STREAMING.REMOVE_ANIM_DICT(info.dict)
+            -- //fix player clipping through the ground after ending low-positioned anims//
+                local current_coords = ENTITY.GET_ENTITY_COORDS(self.get_ped())
+                if PED.IS_PED_IN_ANY_VEHICLE(self.get_ped(), false) then
+                    local veh = PED.GET_VEHICLE_PED_IS_USING(self.get_ped())
+                    PED.SET_PED_INTO_VEHICLE(self.get_ped(), veh, -1)
+                else
+                    ENTITY.SET_ENTITY_COORDS_NO_OFFSET(self.get_ped(), current_coords.x, current_coords.y, current_coords.z, true, false, false)
+                end
+                is_playing_anim = false
+                if spawned_entities[1] ~= nil then
+                    for _, v in ipairs(spawned_entities) do
+                        if ENTITY.DOES_ENTITY_EXIST(v) then
+                            ENTITY.SET_ENTITY_AS_MISSION_ENTITY(v)
+                            script:sleep(100)
+                            ENTITY.DELETE_ENTITY(v)
+                        end
+                    end
+                end
+            end
+            if spawned_npcs[1] ~= nil then
+                for _, v in ipairs(spawned_npcs) do
+                    if ENTITY.DOES_ENTITY_EXIST(v) then
+                        ENTITY.DELETE_ENTITY(v)
+                    end
+                end
+            end
+        end)
+        event.register_handler(menu_event.MenuUnloaded, function()
+            PED.RESET_PED_MOVEMENT_CLIPSET(self.get_ped(), 0.0)
+            PED.SET_PED_RAGDOLL_ON_COLLISION(self.get_ped(), false)
+            if is_playing_anim then
+                TASK.CLEAR_PED_TASKS_IMMEDIATELY(self.get_ped())
+                GRAPHICS.STOP_PARTICLE_FX_LOOPED(loopedFX)
+                STREAMING.REMOVE_NAMED_PTFX_ASSET(info.ptfxdict)
+                STREAMING.REMOVE_ANIM_DICT(info.dict)
+            -- //fix player clipping through the ground after ending low-positioned anims//
+                local current_coords = ENTITY.GET_ENTITY_COORDS(self.get_ped())
+                if PED.IS_PED_IN_ANY_VEHICLE(self.get_ped(), false) then
+                    local veh = PED.GET_VEHICLE_PED_IS_USING(self.get_ped())
+                    PED.SET_PED_INTO_VEHICLE(self.get_ped(), veh, -1)
+                else
+                    ENTITY.SET_ENTITY_COORDS_NO_OFFSET(self.get_ped(), current_coords.x, current_coords.y, current_coords.z, true, false, false)
+                end
+                is_playing_anim = false
+                if spawned_entities[1] ~= nil then
+                    for _, v in ipairs(spawned_entities) do
+                        if ENTITY.DOES_ENTITY_EXIST(v) then
+                            ENTITY.SET_ENTITY_AS_MISSION_ENTITY(v)
+                            script:sleep(100)
+                            ENTITY.DELETE_ENTITY(v)
+                        end
+                    end
+                end
+            end
+            if spawned_npcs[1] ~= nil then
+                for _, v in ipairs(spawned_npcs) do
+                    if ENTITY.DOES_ENTITY_EXIST(v) then
+                        ENTITY.DELETE_ENTITY(v)
+                    end
+                end
+            end
+        end)
         ImGui.EndTabItem()
     end
     if ImGui.BeginTabItem("Scenarios") then
@@ -2021,16 +2061,27 @@ YimActions:add_imgui(function()
             for _, scene in ipairs(filteredScenarios) do
                 table.insert(scenarioNames, scene.name)
             end
-            scenario_index, used = ImGui.ListBox(" ", scenario_index, scenarioNames, #filteredScenarios)
+            scenario_index, used = ImGui.ListBox("##scenarioList", scenario_index, scenarioNames, #filteredScenarios)
         end
         displayFilteredScenarios()
         ImGui.Separator()
         if ImGui.Button("   Play    ") then
+            if is_playing_anim then
+                script.run_in_fiber(function()
+                    TASK.CLEAR_PED_TASKS(self.get_ped())
+                    ENTITY.DELETE_ENTITY(prop1)
+                    ENTITY.DELETE_ENTITY(prop2)
+                    GRAPHICS.STOP_PARTICLE_FX_LOOPED(loopedFX)
+                    if ENTITY.DOES_ENTITY_EXIST(sexPed) then
+                        PED.DELETE_PED(sexPed)
+                    end
+                end)
+            end
             local data = filteredScenarios[scenario_index+1]
-            local coords = ENTITY.GET_ENTITY_COORDS(ped, false)
-            local heading = ENTITY.GET_ENTITY_HEADING(ped)
-            local forwardX = ENTITY.GET_ENTITY_FORWARD_X(ped)
-            local forwardY = ENTITY.GET_ENTITY_FORWARD_Y(ped)
+            local coords = ENTITY.GET_ENTITY_COORDS(self.get_ped(), false)
+            local heading = ENTITY.GET_ENTITY_HEADING(self.get_ped())
+            local forwardX = ENTITY.GET_ENTITY_FORWARD_X(self.get_ped())
+            local forwardY = ENTITY.GET_ENTITY_FORWARD_Y(self.get_ped())
             if data.name == "Cook On BBQ" then
                 script.run_in_fiber(function()
                     while not STREAMING.HAS_MODEL_LOADED(286252949) do
@@ -2040,62 +2091,396 @@ YimActions:add_imgui(function()
                     bbq = OBJECT.CREATE_OBJECT(286252949, coords.x + (forwardX), coords.y + (forwardY), coords.z, true, true, false)
                     ENTITY.SET_ENTITY_HEADING(bbq, heading)
                     OBJECT.PLACE_OBJECT_ON_GROUND_PROPERLY(bbq)
-                    TASK.CLEAR_PED_TASKS_IMMEDIATELY(ped)
-                    TASK.TASK_START_SCENARIO_IN_PLACE(ped, data.scenario, -1, true)
+                    TASK.CLEAR_PED_TASKS_IMMEDIATELY(self.get_ped())
+                    TASK.TASK_START_SCENARIO_IN_PLACE(self.get_ped(), data.scenario, -1, true)
                     is_playing_scenario = true
                 end)
             else
-                script.run_in_fiber(function(script)
-                    TASK.CLEAR_PED_TASKS_IMMEDIATELY(ped)
-                    TASK.TASK_START_SCENARIO_IN_PLACE(ped, data.scenario, -1, true)
+                script.run_in_fiber(function()
+                    TASK.CLEAR_PED_TASKS_IMMEDIATELY(self.get_ped())
+                    TASK.TASK_START_SCENARIO_IN_PLACE(self.get_ped(), data.scenario, -1, true)
                     is_playing_scenario = true
+                    if ENTITY.DOES_ENTITY_EXIST(bbq) then
+                        ENTITY.DELETE_ENTITY(bbq)
+                    end
                 end)
             end
         end
         ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() 
         ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine()
-        if ImGui.Button("   Stop    ") then
+        if ImGui.Button("   Stop   ") then
             if is_playing_scenario then
                 script.run_in_fiber(function(script)
                     busyspinner("Stopping scenario...", 3)
-                    ENTITY.DELETE_ENTITY(bbq)
-                    TASK.CLEAR_PED_TASKS(ped)
+                    TASK.CLEAR_PED_TASKS(self.get_ped())
                     is_playing_scenario = false
-                    script:sleep(2000)
+                    script:sleep(1000)
                     HUD.BUSYSPINNER_OFF()
+                    if ENTITY.DOES_ENTITY_EXIST(bbq) then
+                        ENTITY.DELETE_ENTITY(bbq)
+                    end
                 end)
             end
         end
-        widgetToolTip("TIP: You can also stop scenarios by pressing [Delete] on keyboard or [X] on controller.")
-        event.register_handler(menu_event.ScriptsReloaded, function()
+        widgetToolTip(false, "TIP: You can also stop scenarios by pressing [G] on keyboard or [DPAD LEFT] on controller.")
+        ImGui.Separator()
+        ImGui.Text("Play Scenarios On NPCs:")
+        ImGui.SameLine()
+        coloredText("[Work In Progress]", {247, 185, 104, 0.78})
+        ImGui.PushItemWidth(200)
+        displayNpcs()
+        ImGui.PopItemWidth()
+        ImGui.SameLine()
+        local npcData = filteredNpcs[npc_index + 1]
+        if ImGui.Button("Spawn") then
+            local pedCoords = ENTITY.GET_ENTITY_COORDS(self.get_ped(), false)
+            local pedHeading = ENTITY.GET_ENTITY_HEADING(self.get_ped())
+            local pedForwardX = ENTITY.GET_ENTITY_FORWARD_X(self.get_ped())
+            local pedForwardY = ENTITY.GET_ENTITY_FORWARD_Y(self.get_ped())
+            script.run_in_fiber(function(script)
+                while not STREAMING.HAS_MODEL_LOADED(npcData.hash) do
+                    STREAMING.REQUEST_MODEL(npcData.hash)
+                    coroutine.yield()
+                end
+                npc = PED.CREATE_PED(npcData.group, npcData.hash, 0.0, 0.0, 0.0, 0.0, true, false)
+                ENTITY.SET_ENTITY_INVINCIBLE(npc, true)
+                ENTITY.SET_ENTITY_COORDS_NO_OFFSET(npc, pedCoords.x + pedForwardX * 1.4, pedCoords.y + pedForwardY * 1.4, pedCoords.z, true, false, false)
+                ENTITY.SET_ENTITY_HEADING(npc, pedHeading - 180)
+                table.insert(spawned_npcs, npc)
+                npcNetID2 = NETWORK.NETWORK_GET_NETWORK_ID_FROM_ENTITY(npc)
+                RequestControl(npc, npcNetID2, 250)
+                entToNet(npc, npcNetID2)
+                TASK.TASK_FOLLOW_TO_OFFSET_OF_ENTITY(npc, self.get_ped(), 0.5, 0.5, 0.0, -1, -1, 1.4, true)
+                PED.SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(npc, true) --keeps them from acting like pussies and running away.
+                -- TASK.TASK_SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(npc, true) --complements the previous native but in this case it stops them from following the player.
+            end)
+        end
+        ImGui.SameLine()
+        if ImGui.Button("Delete") then
+            script.run_in_fiber(function()
+                if ENTITY.DOES_ENTITY_EXIST(npc) then
+                    PED.DELETE_PED(npc)
+                end
+                for k, v in ipairs(spawned_npcs) do
+                    table.remove(spawned_npcs, k)
+                    ENTITY.DELETE_ENTITY(v) -- useless
+                end
+            end)
+        end
+        if ImGui.Button(" Play On NPC ") then
+            if ENTITY.DOES_ENTITY_EXIST(npc) then
+                if is_playing_anim then
+                    script.run_in_fiber(function()
+                        TASK.CLEAR_PED_TASKS(npc)
+                        ENTITY.DELETE_ENTITY(prop1)
+                        ENTITY.DELETE_ENTITY(prop2)
+                        GRAPHICS.STOP_PARTICLE_FX_LOOPED(loopedFX)
+                        if ENTITY.DOES_ENTITY_EXIST(sexPed) then
+                            PED.DELETE_PED(sexPed)
+                        end
+                    end)
+                end
+                local data = filteredScenarios[scenario_index+1]
+                local npcCoords = ENTITY.GET_ENTITY_COORDS(npc, false)
+                local npcHeading = ENTITY.GET_ENTITY_HEADING(npc)
+                local npcForwardX = ENTITY.GET_ENTITY_FORWARD_X(npc)
+                local npcForwardY = ENTITY.GET_ENTITY_FORWARD_Y(npc)
+                if data.name == "Cook On BBQ" then
+                    script.run_in_fiber(function()
+                        while not STREAMING.HAS_MODEL_LOADED(286252949) do
+                            STREAMING.REQUEST_MODEL(286252949)
+                            coroutine.yield()
+                        end
+                        bbq = OBJECT.CREATE_OBJECT(286252949, npcCoords.x + (npcForwardX), npcCoords.y + (npcForwardY), npcCoords.z, true, true, false)
+                        ENTITY.SET_ENTITY_HEADING(bbq, npcHeading)
+                        OBJECT.PLACE_OBJECT_ON_GROUND_PROPERLY(bbq)
+                        TASK.CLEAR_PED_TASKS_IMMEDIATELY(npc)
+                        TASK.TASK_START_SCENARIO_IN_PLACE(npc, data.scenario, -1, true)
+                        is_playing_scenario = true
+                    end)
+                else
+                    script.run_in_fiber(function()
+                        TASK.CLEAR_PED_TASKS_IMMEDIATELY(npc)
+                        TASK.TASK_START_SCENARIO_IN_PLACE(npc, data.scenario, -1, true)
+                        is_playing_scenario = true
+                        if ENTITY.DOES_ENTITY_EXIST(bbq) then
+                            ENTITY.DELETE_ENTITY(bbq)
+                        end
+                    end)
+                end
+            else
+                gui.show_error("Yim_Actions", "Spawn an NPC first!")
+            end
+        end
+        ImGui.SameLine()
+        if ImGui.Button("  Stop   ") then
             if is_playing_scenario then
-                ENTITY.DELETE_ENTITY(bbq)
-                TASK.CLEAR_PED_TASKS_IMMEDIATELY(ped)
+                script.run_in_fiber(function(script)
+                    busyspinner("Stopping scenario...", 3)
+                        TASK.CLEAR_PED_TASKS(npc)
+                        TASK.TASK_FOLLOW_TO_OFFSET_OF_ENTITY(npc, self.get_ped(), 0.5, 0.5, 0.0, -1, -1, 1.4, true)
+                        PED.SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(npc, true)
+                        is_playing_scenario = false
+                        script:sleep(1000)
+                        HUD.BUSYSPINNER_OFF()
+                    if ENTITY.DOES_ENTITY_EXIST(bbq) then
+                        ENTITY.DELETE_ENTITY(bbq)
+                    end
+                end)
+            end
+        end
+        event.register_handler(menu_event.ScriptsReloaded, function()
+            if ENTITY.DOES_ENTITY_EXIST(npc) then
+                PED.DELETE_PED(npc)
+            end
+            if is_playing_scenario then
+                TASK.CLEAR_PED_TASKS_IMMEDIATELY(self.get_ped())
+                TASK.CLEAR_PED_TASKS_IMMEDIATELY(npc)
                 is_playing_scenario = false
+                if ENTITY.DOES_ENTITY_EXIST(bbq) then
+                    ENTITY.DELETE_ENTITY(bbq)
+                end
             end
         end)
         event.register_handler(menu_event.MenuUnloaded, function()
+            if ENTITY.DOES_ENTITY_EXIST(npc) then
+                PED.DELETE_PED(npc)
+            end
             if is_playing_scenario then
-                ENTITY.DELETE_ENTITY(bbq)
-                TASK.CLEAR_PED_TASKS_IMMEDIATELY(ped)
+                TASK.CLEAR_PED_TASKS_IMMEDIATELY(self.get_ped())
+                TASK.CLEAR_PED_TASKS_IMMEDIATELY(npc)
                 is_playing_scenario = false
+                if ENTITY.DOES_ENTITY_EXIST(bbq) then
+                    ENTITY.DELETE_ENTITY(bbq)
+                end
             end
         end)
         ImGui.EndTabItem()
+    end
+    local function progressBar()
+        x = x + 0.01
+        if x > 1 then
+            x = 1
+            progessMessage = "Settings Successfully Reset."
+        else
+            progessMessage = "Please Wait..."
+        end
+    end
+    local function displayProgressBar()
+        ImGui.Text(progessMessage)
+        progressBar()
+        ImGui.ProgressBar(x, 250, 25)
+    end
+    if ImGui.BeginTabItem("Settings") then
+        searchBar = false
+        ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.SameLine()
+        ImGui.Text("     ")
+        disableTooltips, used = ImGui.Checkbox("Disable Tooltips", disableTooltips, true)
+        widgetToolTip(false, "Well, it disables this thing.")
+        phoneAnim, used = ImGui.Checkbox("Enable Phone Animations", phoneAnim, true)
+        helpmarker(false, "Restores the disabled phone animations from Single Player.")
+        sprintInside, used = ImGui.Checkbox("Sprint Inside Interiors", sprintInside, true)
+        helpmarker(false, "Allows you to sprint at full speed inside interiors that do not allow it like the Casino.")
+        lockPick, used = ImGui.Checkbox("Use Lockpick Animation", lockPick, true)
+        helpmarker(false, "When stealing vehicles, your character will use the lockpick animation instead of breaking the window.")
+        usePlayKey, used = ImGui.Checkbox("Use Hotkeys For Animations", usePlayKey, true)
+        ImGui.SameLine(); ImGui.TextDisabled("(?)")
+        if ImGui.IsItemHovered() then
+            ImGui.SetNextWindowBgAlpha(0.75)
+            ImGui.BeginTooltip()
+            ImGui.PushTextWrapPos(ImGui.GetFontSize() * 20)
+            ImGui.TextWrapped("Select an animation from the list then use [DELETE] on Keyboard or [X] on Controller to play it while the menu is closed. You can also select the previous/next animation by pressing [PAGE DOWN] to go down the list and [PAGE UP] to go up.\nNOTE: For these hotkeys to work, you have to open Yim_Actions GUI at least once. Browsing the list while the menu is closed is currently not supported for controller.")
+            ImGui.PopTextWrapPos()
+            coloredText("EXPERIMENTAL: This is the only way to use hotkeys with YimMenu at the moment. This was annoying to implement and it will likely be buggy. If it causes issues for you, disable it from Settings. The stop animation hotkey won't be affected.", {240, 3, 50, 0.8})
+            ImGui.EndTooltip()
+        end
+        ImGui.Spacing() ImGui.SameLine() ImGui.Spacing() ImGui.Spacing() ImGui.SameLine() ImGui.Spacing()
+        ImGui.Separator()
+        if Button("Reset Settings", {142, 0, 0, 1}, {142, 0, 0, 0.7}, {142, 0, 0, 0.5}) then
+            ImGui.OpenPopup("##Progress Bar")
+        end
+        widgetToolTip(false, "Revert saved settings and disable all checkboxes.")
+        ImGui.SetNextWindowBgAlpha(0)
+        if ImGui.BeginPopupModal("##Progress Bar", ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.AlwaysAutoResize) then
+                displayProgressBar()
+                resetConfig(default_config)
+                if x == 1 then
+                    counter = counter + 1
+                    if counter > 100 then
+                        ImGui.CloseCurrentPopup()
+                        counter = 0
+                        x = 0
+                        resetCheckBoxes()
+                    else return
+                    end
+                end
+            ImGui.EndPopup()
+        end
+        ImGui.EndTabItem()
+    else
+        searchBar = true
+    end
+end)
+script.register_looped("side features", function(script)
+    script:yield()
+    if phoneAnim then
+        if is_online then
+            if not ENTITY.IS_ENTITY_DEAD(self.get_ped()) then
+                PED.SET_PED_CONFIG_FLAG(self.get_ped(), 242, false)
+                PED.SET_PED_CONFIG_FLAG(self.get_ped(), 243, false)
+                PED.SET_PED_CONFIG_FLAG(self.get_ped(), 244, false)
+                MOBILE.CELL_SET_INPUT(5)
+            end
+        end
+    else
+        PED.SET_PED_CONFIG_FLAG(self.get_ped(), 242, true)
+        PED.SET_PED_CONFIG_FLAG(self.get_ped(), 243, true)
+        PED.SET_PED_CONFIG_FLAG(self.get_ped(), 244, true)
+    end
+    if sprintInside then
+        PED.SET_PED_CONFIG_FLAG(self.get_ped(), 427, true)
+    else
+        PED.SET_PED_CONFIG_FLAG(self.get_ped(), 427, false)
+    end
+    if lockPick then
+        PED.SET_PED_CONFIG_FLAG(self.get_ped(), 426, true)
+    else
+        PED.SET_PED_CONFIG_FLAG(self.get_ped(), 426, false)
     end
 end)
 script.register_looped("scenario hotkey", function(hotkey)
     hotkey:yield()
     if is_playing_scenario then
-        if PAD.IS_CONTROL_PRESSED(0, 256) then
+        if PAD.IS_CONTROL_PRESSED(0, 47) then
             script.run_in_fiber(function(script)
                 busyspinner("Stopping scenario...", 3)
-                ENTITY.DELETE_ENTITY(bbq)
-                TASK.CLEAR_PED_TASKS(ped)
-                is_playing_scenario = false
-                script:sleep(2000)
+                TASK.CLEAR_PED_TASKS(self.get_ped())
+                TASK.CLEAR_PED_TASKS(npc)
+                TASK.TASK_FOLLOW_TO_OFFSET_OF_ENTITY(npc, self.get_ped(), 0.5, 0.5, 0.0, -1, -1, 1.4, true)
+                script:sleep(1000)
                 HUD.BUSYSPINNER_OFF()
+                if ENTITY.DOES_ENTITY_EXIST(bbq) then
+                    ENTITY.DELETE_ENTITY(bbq)
+                end
+                is_playing_scenario = false
             end)
+        end
+    end
+end)
+
+function helpmarker(colorFlag, text, color)
+    if not disableTooltips then
+        ImGui.SameLine()
+        ImGui.TextDisabled("(?)")
+        if ImGui.IsItemHovered() then
+            ImGui.SetNextWindowBgAlpha(0.75)
+            ImGui.BeginTooltip()
+            if colorFlag == true then
+                coloredText(text, color)
+            else
+                ImGui.PushTextWrapPos(ImGui.GetFontSize() * 20)
+                ImGui.TextWrapped(text)
+                ImGui.PopTextWrapPos()
+            end
+            ImGui.EndTooltip()
+        end
+    end
+end
+
+function widgetToolTip(colorFlag, text, color)
+    if not disableTooltips then
+        if ImGui.IsItemHovered() then
+            ImGui.SetNextWindowBgAlpha(0.75)
+            ImGui.BeginTooltip()
+            if colorFlag == true then
+                coloredText(text, color)
+            else
+                ImGui.PushTextWrapPos(ImGui.GetFontSize() * 20)
+                ImGui.TextWrapped(text)
+                ImGui.PopTextWrapPos()
+            end
+            ImGui.EndTooltip()
+        end
+    end
+end
+
+script.register_looped("animation hotkey", function(script)
+    script:yield()
+    if is_playing_anim then
+        if spawned_npcs[1] ~= nil then
+            if PAD.IS_CONTROL_PRESSED(0, 47) then
+                for k, v in ipairs(spawned_npcs) do
+                    if PED.IS_PED_IN_ANY_VEHICLE(self.get_ped(), false) then
+                        local veh = PED.GET_VEHICLE_PED_IS_USING(self.get_ped())
+                        cleanup()
+                        PED.SET_PED_INTO_VEHICLE(self.get_ped(), veh, -1)
+                        cleanupNPC()
+                        PED.SET_PED_INTO_VEHICLE(v, veh, 0)
+                    else
+                        cleanup()
+                        cleanupNPC()
+                        local current_coords = ENTITY.GET_ENTITY_COORDS(self.get_ped())
+                        local npc_coords = ENTITY.GET_ENTITY_COORDS(v)
+                        ENTITY.SET_ENTITY_COORDS_NO_OFFSET(self.get_ped(), current_coords.x, current_coords.y, current_coords.z, true, false, false)
+                        ENTITY.SET_ENTITY_COORDS_NO_OFFSET(v, npc_coords.x, npc_coords.y, npc_coords.z, true, false, false)
+                        TASK.TASK_FOLLOW_TO_OFFSET_OF_ENTITY(v, self.get_ped(), 0.5, 0.5, 0.0, -1, -1, 1.4, true)
+                        PED.SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(v, true)
+                    end
+                end
+                is_playing_anim = false
+            end
+        else
+            if PAD.IS_CONTROL_PRESSED(0, 47) then
+                cleanup()
+                is_playing_anim = false
+            end
+        end
+    end
+    if usePlayKey and info ~= nil then
+        if PAD.IS_CONTROL_PRESSED(0, 317) then
+            anim_index = anim_index + 1
+            info = filteredAnims[anim_index + 1]
+            if info == nil then
+                anim_index = 0
+                info = filteredAnims[anim_index + 1]
+                gui.show_message("Current Animation:", info.name)
+            end
+            if info ~= nil then
+                gui.show_message("Current Animation:", info.name)
+            end
+            script:sleep(200) -- average inter-key interval is about what, 250ms? this should be enough.
+        elseif PAD.IS_CONTROL_PRESSED(0, 316) and anim_index > 0 then -- prevent going to index 0 which breaks the script.
+            anim_index = anim_index - 1
+            info = filteredAnims[anim_index + 1]
+            gui.show_message("Current Animation:", info.name)
+            script:sleep(200)
+        elseif PAD.IS_CONTROL_PRESSED(0, 316) and anim_index == 0 then
+                info = filteredAnims[anim_index + 1]
+                gui.show_warning("Current Animation:", info.name.."\n\nYou have reached the top of the list.")
+                script:sleep(400)
+        end
+        if PAD.IS_CONTROL_PRESSED(0, 256) then
+            if not is_playing_anim then
+                if info ~= nil then
+                    local coords = ENTITY.GET_ENTITY_COORDS(self.get_ped(), false)
+                    local heading = ENTITY.GET_ENTITY_HEADING(self.get_ped())
+                    local forwardX = ENTITY.GET_ENTITY_FORWARD_X(self.get_ped())
+                    local forwardY = ENTITY.GET_ENTITY_FORWARD_Y(self.get_ped())
+                    local boneIndex = PED.GET_PED_BONE_INDEX(self.get_ped(), info.boneID)
+                    local bonecoords = PED.GET_PED_BONE_COORDS(self.get_ped(), info.boneID)
+                    if manualFlags then
+                        setmanualflag()
+                    else
+                        flag = info.flag
+                    end
+                    playSelected(self.get_ped(), sexPed, boneIndex, coords, heading, forwardX, forwardY, bonecoords)
+                    script:sleep(200)
+                end
+            else
+                PAD.SET_CONTROL_SHAKE(0, 500, 250)
+                gui.show_message("Yim_Actions", "Press "..stopButton.." to stop the current animation before playing the next one.")
+                script:sleep(800)
+            end
         end
     end
 end)
@@ -3108,22 +3493,17 @@ toolTip(Gif, "Once you are done, get out and have them get in, then spam the Gif
 toolTip(Gif, "NOTE: Gifted vehicles SHOULD come fully insured, MAKE SURE THEY CHECK IT IN LS CUSTOMS!")
 
 local tokyodrift = Veh:add_tab("Tokyo Drift")
-script.register_looped("playerID", function(playerID)
+script.register_looped("vars", function(vars)
     if NETWORK.NETWORK_IS_SESSION_ACTIVE() then
         is_online = true
-        onlinePed = PLAYER.GET_PLAYER_PED_SCRIPT_INDEX(PLAYER.PLAYER_ID())
     else
         is_online = false
-        spPed = self.get_ped()
     end
-    if is_online then
-        ped = onlinePed
-    else
-        ped = spPed
+    if PED.IS_PED_IN_ANY_VEHICLE(self.get_ped()) then
+        current_vehicle = PED.GET_VEHICLE_PED_IS_USING(self.get_ped())
+        is_car = VEHICLE.IS_THIS_MODEL_A_CAR(ENTITY.GET_ENTITY_MODEL(current_vehicle))
     end
-    current_vehicle = PED.GET_VEHICLE_PED_IS_USING(ped)
-    is_car = VEHICLE.IS_THIS_MODEL_A_CAR(ENTITY.GET_ENTITY_MODEL(current_vehicle))
-    playerID:yield()
+    vars:yield()
 end)
 local ShiftDrift = false
 local DriftIntensity = 0
@@ -3138,7 +3518,7 @@ tokyodrift:add_imgui(function()
 manufacturer = VEHICLE.GET_MAKE_NAME_FROM_VEHICLE_MODEL(ENTITY.GET_ENTITY_MODEL(current_vehicle))
 mfr_name = (manufacturer:lower():gsub("^%l", string.upper))
 vehicle_name = vehicles.get_vehicle_display_name(ENTITY.GET_ENTITY_MODEL(current_vehicle))
-    if PED.IS_PED_IN_ANY_VEHICLE(ped, true) and is_car then
+    if PED.IS_PED_IN_ANY_VEHICLE(self.get_ped(), true) and is_car then
         ImGui.Text("Vehicle: "..mfr_name.." "..vehicle_name)
         ImGui.Spacing()
         ShiftDrift, shiftDriftToggled = ImGui.Checkbox("Activate Tokyo Drift", ShiftDrift, true)
@@ -3165,15 +3545,17 @@ vehicle_name = vehicles.get_vehicle_display_name(ENTITY.GET_ENTITY_MODEL(current
         if not DriftTires then
             ImGui.Spacing()
             ImGui.Text("Intensity:")
-            DriftIntensity, DriftIntensityUsed = ImGui.SliderInt("", DriftIntensity, 0, 3)
+            ImGui.PushItemWidth(250)
+            DriftIntensity, DriftIntensityUsed = ImGui.SliderInt("##Intensity", DriftIntensity, 0, 3)
             if ImGui.IsItemHovered() then
                 ImGui.BeginTooltip()
                 ImGui.Text("0: No Grip (very stiff).\n1: Balanced (Recommended).\n2: Weak Drift.\n3: Weakest Drift.")
                 ImGui.EndTooltip()
             end
+            ImGui.PopItemWidth()
         end
-    elseif PED.IS_PED_IN_ANY_VEHICLE(ped, true) and not is_car then
-        ImGui.Text("Tokyo Drift only works on cars and trucks.\n"..current_vehicle)
+    elseif PED.IS_PED_IN_ANY_VEHICLE(self.get_ped(), true) and not is_car then
+        ImGui.Text("Tokyo Drift only works on cars and trucks.")
     else
         ImGui.Text("Get in a vehicle before using the script!")
     end
@@ -3215,24 +3597,26 @@ vehicle_name = vehicles.get_vehicle_display_name(ENTITY.GET_ENTITY_MODEL(current
     end
 end)
 event.register_handler(menu_event.MenuUnloaded, function()
- resettokyodrift()
+    resettokyodrift()
 end)
 event.register_handler(menu_event.ScriptsReloaded, function()
- resettokyodrift()
+    resettokyodrift()
 end)
 script.register_looped("Drift Loop", function(script)
     script:yield()
-    if is_car and DriftTires and PAD.IS_CONTROL_PRESSED(0, 21) then
-        VEHICLE.SET_DRIFT_TYRES(current_vehicle, true)
-    else
-        VEHICLE.SET_DRIFT_TYRES(current_vehicle, false)
-    end
-    script:yield()
-    if is_car and ShiftDrift and PAD.IS_CONTROL_PRESSED(0, 21) and not DriftTires then
-        VEHICLE.SET_VEHICLE_REDUCE_GRIP(current_vehicle, true)
-        VEHICLE.SET_VEHICLE_REDUCE_GRIP_LEVEL(current_vehicle, DriftIntensity)
-    else
-        VEHICLE.SET_VEHICLE_REDUCE_GRIP(current_vehicle, false)
+    if PED.IS_PED_IN_ANY_VEHICLE(self.get_ped(), true) then
+        if is_car and DriftTires and PAD.IS_CONTROL_PRESSED(0, 21) then
+            VEHICLE.SET_DRIFT_TYRES(current_vehicle, true)
+        else
+            VEHICLE.SET_DRIFT_TYRES(current_vehicle, false)
+        end
+        script:yield()
+        if is_car and ShiftDrift and PAD.IS_CONTROL_PRESSED(0, 21) and not DriftTires then
+            VEHICLE.SET_VEHICLE_REDUCE_GRIP(current_vehicle, true)
+            VEHICLE.SET_VEHICLE_REDUCE_GRIP_LEVEL(current_vehicle, DriftIntensity)
+        else
+            VEHICLE.SET_VEHICLE_REDUCE_GRIP(current_vehicle, false)
+        end
     end
 end)
  -- Global Player Options

--- a/Extras-data.lua
+++ b/Extras-data.lua
@@ -2257,10 +2257,10 @@ weaponModels = {
 }
 
 animlist =  {
-    { dict = "amb@world_human_drinking@beer@male@idle_a", anim = "idle_a", name = "MISC: Drink Beer", prop1 = 2010247122, boneID = 28422, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_drinking@coffee@male@idle_a", anim = "idle_c", name = "MISC: Drink Coffee", prop1 = 4161278897, boneID = 64096, posx = 0.01, posy = 0.055, posz = -0.005, rotx = -15.0, roty = 5.0, rotz = -87.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "amb@code_human_wander_eating_donut@male@base", anim = "static", name = "MISC: Eat Donut", prop1 = 3992024553, boneID = 64096, posx = 0.06, posy = 0.05, posz = 0.02, rotx = -90.0, roty = 180.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_seat_wall_eating@male@both_hands@idle_a", anim = "idle_c", name = "MISC: Eat Taco", prop1 = 1655278098, boneID = 64096, posx = 0.1, posy = 0.05, posz = 0.01, rotx = -25.0, roty = 0.0, rotz = 290.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "amb@world_human_drinking@beer@male@idle_a", anim = "idle_a", name = "MISC: Drink Beer", prop1 = 2010247122, boneID = 28422, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "amb@world_human_drinking@coffee@male@idle_a", anim = "idle_c", name = "MISC: Drink Coffee", prop1 = 4161278897, boneID = 64096, posx = 0.01, posy = 0.055, posz = -0.005, rotx = -15.0, roty = 5.0, rotz = -87.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "amb@code_human_wander_eating_donut@male@base", anim = "static", name = "MISC: Eat Donut", prop1 = 3992024553, boneID = 64096, posx = 0.06, posy = 0.05, posz = 0.02, rotx = -90.0, roty = 180.0, rotz = 0.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "amb@world_human_seat_wall_eating@male@both_hands@idle_a", anim = "idle_c", name = "MISC: Eat Taco", prop1 = 1655278098, boneID = 64096, posx = 0.1, posy = 0.05, posz = 0.01, rotx = -25.0, roty = 0.0, rotz = 290.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
     { dict = "amb@world_human_aa_smoke@male@idle_a", anim = "idle_a", name = "MISC: Smoke Cigarette 01", prop1 = 3269700402, boneID = 28422, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "core", ptfxname = "ent_anim_cig_smoke", ptfxdelay = 0, ptfxscale = 1, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 5, propColl = true, prop2 = 0},
     { dict = "amb@world_human_leaning@female@wall@back@hand_up@base", anim = "base", name = "MISC: Smoke Cigarette 02", prop1 = 3269700402, boneID = 64096, posx = 0.0, posy = 0.0, posz = -0.01, rotx = 0.0, roty = 0.0, rotz = 60.0, flag = 33, ptfxdict = "core", ptfxname = "ent_anim_cig_smoke", ptfxdelay = 0, ptfxscale = 1, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 5, propColl = true, prop2 = 0},
     { dict = "amb@world_human_aa_smoke@male@idle_a", anim = "idle_a", name = "MISC: Smoke Cigar", prop1 = 3909405573, boneID = 64096, posx = 0.02069, posy = -0.01, posz = -0.02, rotx = 50.0, roty = 0.0, rotz = -80.0, flag = 49, ptfxdict = "core", ptfxname = "ent_anim_cig_smoke", ptfxdelay = 0, ptfxscale = 1, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 5, propColl = true, prop2 = 0},
@@ -2268,191 +2268,199 @@ animlist =  {
     { dict = "amb@world_human_musician@guitar@male@idle_a", anim = "idle_b", name = "Activity: Guitar (acoustic)", prop1 = 3586178055, boneID = 24818, posx = -0.06, posy = 0.29, posz = 0.18, rotx = 10.0, roty = 348.0, rotz = 161.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
     { dict = "amb@world_human_musician@guitar@male@idle_a", anim = "idle_a", name = "Activity: Guitar (electric)", prop1 = 61087258, boneID = 24818, posx = -0.01, posy = 0.27, posz = 0.18, rotx = 14.0, roty = 348.0, rotz = 161.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
     { dict = "oddjobs@taxi@gyn@cc@hotbox", anim = "idle_b", name = "Car: Smoke Cigarette (in-car)", prop1 = 3269700402, boneID = 28422, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "core", ptfxname = "ent_anim_cig_smoke", ptfxdelay = 0, ptfxscale = 1, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 5, propColl = true, prop2 = 0},
-    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Pizza Box", prop1 = 3438383125, boneID = 28422, posx = 0.01, posy = -0.1, posz = -0.159, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Money Suitcase", prop1 = 1452661060, boneID = 28422, posx = 0.0, posy = -0.35, posz = -0.12, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry T-Shirt Box", prop1 = 296207441, boneID = 28422, posx = -0.01, posy = -0.3, posz = -0.180, rotx = 0.0, roty = 0.0, rotz = 90.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Beer Box", prop1 = 1661171057, boneID = 28422, posx = -0.01, posy = -0.1, posz = -0.02, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Weed Plant", prop1 = 3366029953, boneID = 28422, posx = -0.005, posy = -0.12, posz = -0.18, rotx = 20.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Weed Package", prop1 = 1009806427, boneID = 28422, posx = -0.02, posy = -0.28, posz = -0.2, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Cocaine Package", prop1 = 1188944846, boneID = 28422, posx = 0.0, posy = -0.2, posz = -0.05, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Meth Package", prop1 = 125438837, boneID = 28422, posx = 0.0, posy = -0.3, posz = -0.18, rotx = 0.0, roty = 0.0, rotz = 90.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Dead Body 01", prop1 = 462487855, boneID = 28422, posx = -0.15, posy = -0.15, posz = -0.2, rotx = -20.0, roty = -30.0, rotz = 180.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Dead Body 02", prop1 = 2416598663, boneID = 28422, posx = 0.15, posy = -0.05, posz = -0.2, rotx = 20.0, roty = 35.0, rotz = 180.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "anim@heists@narcotics@trash", anim = "idle", name = "MISC: Carry Trash", prop1 = 3619689535, boneID = 28422, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "anim@heists@narcotics@trash", anim = "idle", name = "MISC: Carry Katana", prop1 = 3803840879, boneID = 28422, posx = 0.0, posy = -0.03, posz = 0.02, rotx = -60.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "missfinale_c2ig_11", anim = "pushcar_offcliff_f", name = "Action: Push", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 50, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@prop_human_bum_shopping_cart@male@idle_a", anim = "idle_c", name = "HOBO Trolley", prop1 = 4064921930, boneID = 0, posx = 0.0, posy = 1.05, posz = -0.5, rotx = 0.0, roty = 0.0, rotz = 180.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 3, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_bum_freeway@male@idle_a", anim = "idle_a", name = "HOBO Begging", prop1 = 4049581021, boneID = 28422, posx = 0.0, posy = 0.0, posz = 0.08, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_bum_slumped@male@laying_on_left_side@idle_a", anim = "idle_c", name = "HOBO Sleeping", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "missfbi1", anim = "ledge_loop", name = "MISC: Naruto Run (probably. idk)", prop1 = 3760607069, boneID = 12844, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 90.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "amb@code_human_in_car_mp_actions@grab_crotch@low@ds@base", anim = "idle_a", name = "NSFW: Smells So Good!", prop1 = 2881667978, boneID = 12844, posx = 0.12, posy = 0.0, posz = 0.003, rotx = 90.0, roty = 90.0, rotz = 180.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "timetable@ron@ig_3_couch", anim = "base", name = "MISC: Sit On Chair 01", prop1 = 3186063286, boneID = 23553, posx = -0.21, posy = 0.0, posz = 0.0, rotx = 185.0, roty = 86.0, rotz = -20.0, flag = 34, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "random@crash_rescue@get_victim_to_friend", anim = "helping_friend_idle_friend", name = "MISC: Sit On Chair 02", prop1 = 1103738692, boneID = 23553, posx = 0.03, posy = -0.03, posz = 0.0, rotx = 185.0, roty = 92.1069420, rotz = 50.0, flag = 34, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "timetable@ron@ig_5_p3", anim = "ig_5_p3_base", name = "MISC: Sit On Chair 03", prop1 = 2278414290, boneID = 23553, posx = -0.46, posy = -0.46, posz = -0.1, rotx = 180.0, roty = 96.0, rotz = 35.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "timetable@reunited@ig_10", anim = "base_amanda", name = "MISC: Sit On Chair 04", prop1 = 725259233, boneID = 23553, posx = -0.46, posy = -0.46, posz = 0.05, rotx = 180.0, roty = 85.0, rotz = 35.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "switch@michael@sunlounger", anim = "sunlounger_idle", name = "MISC: Relax On Lounger", prop1 = 3721259803, boneID = 23553, posx = 0.09, posy = -0.595555, posz = 0.0, rotx = 178.0, roty = 91.0, rotz = 60.0, flag = 34, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_stupor@male@idle_a", anim = "idle_a", name = "MISC: Sit On Ground 01", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_picnic@male@idle_a", anim = "idle_a", name = "MISC: Sit On Ground 02", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "timetable@jimmy@mics3_ig_15@", anim = "idle_a_jimmy", name = "MISC: Sit On Ground (knee up)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@amb@business@bgen@bgen_no_work@", anim = "sit_phone_phoneputdown_idle_nowork", name = "MISC: Sit On Ground (both knees up)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_picnic@female@base", anim = "base", name = "MISC: Sit On Ground (female)", prop1 = 951345131, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 3, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_sunbathe@male@back@base", anim = "base", name = "MISC: Sunbathe", prop1 = 1280564504, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, type = 4, propColl = true, prop2 = 0},
-    { dict = "timetable@tracy@sleep@", anim = "idle_b", name = "MISC: Sleep", prop1 = 3314781611, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, type = 4, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_leaning@female@wall@back@holding_elbow@base", anim = "base", name = "MISC: Lean Back Hold Elbow", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_leaning@male@wall@back@foot_up@aggro_react", anim = "aggro_react_forward_exit", name = "MISC: Lean Back Foot Up", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 34, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, propColl = true, prop2 = 0},
-    { dict = "anim@amb@nightclub@gt_idle@", anim = "base", name = "MISC: Lean Back On Rail/Ledge", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 34, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, propColl = true, prop2 = 0},
-    { dict = "switch@michael@sitting_on_car_bonnet", anim = "sitting_on_car_bonnet_loop", name = "Car: Sit On Car Hood", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, propColl = true, prop2 = 0},
-    { dict = "timetable@mime@01_gc", anim = "idle_a", name = "MISC: Lean On Elbow Left", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, propColl = true, prop2 = 0},
-    { dict = "misscarstealfinale", anim = "packer_idle_1_trevor", name = "MISC: Lean On Hand Left", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, propColl = true, prop2 = 0},
-    { dict = "misscarsteal2fixer", anim = "confused_a", name = "Car: Mechanic 01", prop1 = 1996755764, boneID = 6286, posx = 0.05, posy = 0.01, posz = -0.02, rotx = 100.0, roty = -30.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, type = 1, propColl = true, prop2 = 0},
-    { dict = "anim@amb@garage@chassis_repair@", anim = "idle_02_amy_skater_01", name = "Car: Mechanic 02", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, propColl = true, prop2 = 0},
-    { dict = "missarmenian2", anim = "standing_idle_loop_drunk", name = "Movement: Drunk (static)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, propColl = true, prop2 = 0},
-    { dict = "random@drunk_driver_1", anim = "drunk_driver_stand_loop_dd2", name = "Movement: Drunk", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, propColl = true, prop2 = 0},
-    { dict = "anim@amb@nightclub@lazlow@hi_dancefloor@", anim = "crowddance_hi_11_raiseup_laz", name = "Activity: Dance 01", prop1 = 3324004640, boneID = 64096, posx = 0.02481, posy = 0.05, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, propColl = true, type = 1, prop2 = 0},
-    { dict = "anim@amb@nightclub@dancers@solomun_entourage@", anim = "mi_dance_prop_15_v1_male^1", name = "Activity: Dance 06", prop1 = 1940235411, boneID = 64096, posx = 0.015, posy = 0.04, posz = -0.12, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, propColl = true, type = 1, prop2 = 0},
-    { dict = "anim@amb@nightclub@mini@dance@dance_solo@sand_trip@", anim = "high_left_up", name = "Activity: Dance 02", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, propColl = true, prop2 = 0},
-    { dict = "anim@amb@nightclub@dancers@dixon_entourage@", anim = "mi_dance_facedj_15_v1_male^4", name = "Activity: Dance 03", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, propColl = true, prop2 = 0},
-    { dict = "missbigscore1switch_trevor_piss", anim = "piss_loop", name = "Action: Take A Piss", prop1 = 0, boneID = 11816, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "scr_amb_chop", ptfxname = "ent_anim_dog_peeing", ptfxdelay = 300, ptfxscale = 1.0, ptfxOffx = 0.1, ptfxOffy = 0.1369101, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 40.0, ptfxrotz = 90.0, type = 2, propColl = true, prop2 = 0},
-    { dict = "switch@trevor@on_toilet", anim = "trev_on_toilet_loop", name = "Action: Take A Shit", prop1 = 0, boneID = 11816, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "scr_amb_chop", ptfxname = "ent_anim_dog_poo", ptfxdelay = 500, ptfxscale = 1.0, ptfxOffx = 0.2, ptfxOffy = -0.15, ptfxOffz = -0.1, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2, propColl = true, prop2 = 0},
-    { dict = "anim@move_f@grooving@", anim = "walk", name = "Movement: Goofy Walk", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = -0.0, rotx= 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "",  ptfxdelay = 0, ptfxscale = 0, propColl = true, prop2 = 0},
-    { dict = "move_m@joy@a", anim = "walk", name = "Movement: Boss Walk", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = -0.0, rotx= 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "",  ptfxdelay = 0, ptfxscale = 0, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_jog_standing@female@idle_a", anim = "idle_a", name = "Movement: Goofy Run", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = -0.0, rotx= 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "",  ptfxdelay = 0, ptfxscale = 0, propColl = true, prop2 = 0},
-    { dict = "anim@amb@nightclub@djs@solomun@", anim = "sol_sync_b_sol", name = "Activity: DJ 01 (Solomun)", prop1 = 2767137151, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx= 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 3, propColl = true, prop2 = 0},
-    { dict = "anim@amb@nightclub@djs@dixon@", anim = "dixn_sync_cntr_g_dix", name = "Activity: DJ 02 (Dixon)", prop1 = 2767137151, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx= 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 3, propColl = true, prop2 = 0},
-    { dict = "anim@amb@nightclub@djs@black_madonna@", anim = "pose_a_idle_e_blamadon", name = "Activity: DJ 03 (Black Madonna)", prop1 = 2767137151, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx= 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 3, propColl = true, prop2 = 0},
-    { dict = "mini@strip_club@idles@dj@idle_02", anim = "idle_02", name = "Activity: DJ 04", prop1 = 976772591, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 3, propColl = true, prop2 = 0},
-    { dict = "switch@franklin@press_ups", anim = "pressups_loop", name = "Activity: Push-ups", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_sit_ups@male@base", anim = "base", name = "Activity: Sit-ups", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@mp_player_intincarrockstd@ps@", anim = "idle_a", name = "Gesture: Metal", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_stand_fishing@idle_a", anim = "idle_a", name = "Activity: Fishing", prop1 = 2384362703, boneID = 36029, posx = 0.1, posy = 0.08, posz = 0.03, rotx = 0, roty = 267, rotz = 230, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_stand_mobile@male@text@base", anim = "base", name = "MISC: Browse Phone", prop1 = 3083764787, boneID = 28422, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Pizza Box", prop1 = 3438383125, boneID = 28422, posx = 0.01, posy = -0.1, posz = -0.159, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Money Suitcase", prop1 = 1452661060, boneID = 28422, posx = 0.0, posy = -0.35, posz = -0.12, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry T-Shirt Box", prop1 = 296207441, boneID = 28422, posx = -0.01, posy = -0.3, posz = -0.180, rotx = 0.0, roty = 0.0, rotz = 90.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Beer Box", prop1 = 1661171057, boneID = 28422, posx = -0.01, posy = -0.1, posz = -0.02, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Weed Plant", prop1 = 3366029953, boneID = 28422, posx = -0.005, posy = -0.12, posz = -0.18, rotx = 20.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Weed Package", prop1 = 1009806427, boneID = 28422, posx = -0.02, posy = -0.28, posz = -0.2, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Cocaine Package", prop1 = 1188944846, boneID = 28422, posx = 0.0, posy = -0.2, posz = -0.05, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Meth Package", prop1 = 125438837, boneID = 28422, posx = 0.0, posy = -0.3, posz = -0.18, rotx = 0.0, roty = 0.0, rotz = 90.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Dead Body 01", prop1 = 462487855, boneID = 28422, posx = -0.15, posy = -0.15, posz = -0.2, rotx = -20.0, roty = -30.0, rotz = 180.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "anim@heists@box_carry@", anim = "idle", name = "MISC: Carry Dead Body 02", prop1 = 2416598663, boneID = 28422, posx = 0.15, posy = -0.05, posz = -0.2, rotx = 20.0, roty = 35.0, rotz = 180.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "anim@heists@narcotics@trash", anim = "idle", name = "MISC: Carry Trash", prop1 = 3619689535, boneID = 28422, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "anim@heists@narcotics@trash", anim = "idle", name = "MISC: Carry Katana", prop1 = 3803840879, boneID = 28422, posx = 0.0, posy = -0.03, posz = 0.02, rotx = -60.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "missfinale_c2ig_11", anim = "pushcar_offcliff_f", name = "Action: Push", flag = 50},
+    { dict = "amb@prop_human_bum_shopping_cart@male@idle_a", anim = "idle_c", name = "HOBO Trolley", prop1 = 4064921930, boneID = 0, posx = 0.0, posy = 1.05, posz = -0.5, rotx = 0.0, roty = 0.0, rotz = 180.0, flag = 33, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 3, propColl = true, prop2 = 0},
+    { dict = "amb@world_human_bum_freeway@male@idle_a", anim = "idle_a", name = "HOBO Begging", prop1 = 4049581021, boneID = 28422, posx = 0.0, posy = 0.0, posz = 0.08, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "amb@world_human_bum_slumped@male@laying_on_left_side@idle_a", anim = "idle_c", name = "HOBO Sleeping", flag = 33},
+    { dict = "missfbi1", anim = "ledge_loop", name = "MISC: Naruto Run (probably. idk)", prop1 = 3760607069, boneID = 12844, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 90.0, rotz = 0.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "amb@code_human_in_car_mp_actions@grab_crotch@low@ds@base", anim = "idle_a", name = "NSFW: Smells So Good!", prop1 = 2881667978, boneID = 12844, posx = 0.12, posy = 0.0, posz = 0.003, rotx = 90.0, roty = 90.0, rotz = 180.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "timetable@ron@ig_3_couch", anim = "base", name = "MISC: Sit On Chair 01", prop1 = 3186063286, boneID = 23553, posx = -0.21, posy = 0.0, posz = 0.0, rotx = 185.0, roty = 86.0, rotz = -20.0, flag = 34, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "random@crash_rescue@get_victim_to_friend", anim = "helping_friend_idle_friend", name = "MISC: Sit On Chair 02", prop1 = 1103738692, boneID = 23553, posx = 0.03, posy = -0.03, posz = 0.0, rotx = 185.0, roty = 92.1069420, rotz = 50.0, flag = 34, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "timetable@ron@ig_5_p3", anim = "ig_5_p3_base", name = "MISC: Sit On Chair 03", prop1 = 2278414290, boneID = 23553, posx = -0.46, posy = -0.46, posz = -0.1, rotx = 180.0, roty = 96.0, rotz = 35.0, flag = 33, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "timetable@reunited@ig_10", anim = "base_amanda", name = "MISC: Sit On Chair 04", prop1 = 725259233, boneID = 23553, posx = -0.46, posy = -0.46, posz = 0.05, rotx = 180.0, roty = 85.0, rotz = 35.0, flag = 33, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "switch@michael@sunlounger", anim = "sunlounger_idle", name = "MISC: Relax On Lounger", prop1 = 3721259803, boneID = 23553, posx = 0.09, posy = -0.595555, posz = 0.0, rotx = 178.0, roty = 91.0, rotz = 60.0, flag = 34, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "amb@world_human_stupor@male@idle_a", anim = "idle_a", name = "MISC: Sit On Ground 01", flag = 47},
+    { dict = "amb@world_human_picnic@male@idle_a", anim = "idle_a", name = "MISC: Sit On Ground 02", flag = 47},
+    { dict = "timetable@jimmy@mics3_ig_15@", anim = "idle_a_jimmy", name = "MISC: Sit On Ground (knee up)", flag = 47},
+    { dict = "anim@amb@business@bgen@bgen_no_work@", anim = "sit_phone_phoneputdown_idle_nowork", name = "MISC: Sit On Ground (both knees up)", flag = 47},
+    { dict = "amb@world_human_picnic@female@base", anim = "base", name = "MISC: Sit On Ground (female)", prop1 = 951345131, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 3, propColl = true, prop2 = 0},
+    { dict = "amb@world_human_sunbathe@male@back@base", anim = "base", name = "MISC: Sunbathe", prop1 = 1280564504, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, type = 4, propColl = true, prop2 = 0},
+    { dict = "timetable@tracy@sleep@", anim = "idle_b", name = "MISC: Sleep", prop1 = 3314781611, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, type = 4, propColl = true, prop2 = 0},
+    { dict = "amb@world_human_leaning@female@wall@back@holding_elbow@base", anim = "base", name = "MISC: Lean Back Hold Elbow", flag = 33,},
+    { dict = "amb@world_human_leaning@male@wall@back@foot_up@aggro_react", anim = "aggro_react_forward_exit", name = "MISC: Lean Back Foot Up", flag = 34,},
+    { dict = "anim@amb@nightclub@gt_idle@", anim = "base", name = "MISC: Lean Back On Rail/Ledge", flag = 34,},
+    { dict = "switch@michael@sitting_on_car_bonnet", anim = "sitting_on_car_bonnet_loop", name = "Car: Sit On Car Hood", flag = 33,},
+    { dict = "timetable@mime@01_gc", anim = "idle_a", name = "MISC: Lean On Elbow Left", flag = 33,},
+    { dict = "misscarstealfinale", anim = "packer_idle_1_trevor", name = "MISC: Lean On Hand Left", flag = 33,},
+    { dict = "misscarsteal2fixer", anim = "confused_a", name = "Car: Mechanic 01", prop1 = 1996755764, boneID = 6286, posx = 0.05, posy = 0.01, posz = -0.02, rotx = 100.0, roty = -30.0, rotz = 0.0, flag = 33, type = 1},
+    { dict = "anim@amb@garage@chassis_repair@", anim = "idle_02_amy_skater_01", name = "Car: Mechanic 02", flag = 33,},
+    { dict = "missarmenian2", anim = "standing_idle_loop_drunk", name = "Movement: Drunk (static)", flag = 33,},
+    { dict = "random@drunk_driver_1", anim = "drunk_driver_stand_loop_dd2", name = "Movement: Drunk", flag = 49,},
+    { dict = "anim@amb@nightclub@lazlow@hi_dancefloor@", anim = "crowddance_hi_11_raiseup_laz", name = "Activity: Dance 01", prop1 = 3324004640, boneID = 64096, posx = 0.02481, posy = 0.05, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, propColl = true, type = 1, prop2 = 0},
+    { dict = "anim@amb@nightclub@dancers@solomun_entourage@", anim = "mi_dance_prop_15_v1_male^1", name = "Activity: Dance 06", prop1 = 1940235411, boneID = 64096, posx = 0.015, posy = 0.04, posz = -0.12, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, propColl = true, type = 1, prop2 = 0},
+    { dict = "anim@amb@nightclub@mini@dance@dance_solo@sand_trip@", anim = "high_left_up", name = "Activity: Dance 02", flag = 33,},
+    { dict = "anim@amb@nightclub@dancers@dixon_entourage@", anim = "mi_dance_facedj_15_v1_male^4", name = "Activity: Dance 03", flag = 33,},
+    { dict = "missbigscore1switch_trevor_piss", anim = "piss_loop", name = "Action: Take A Piss", flag = 49, ptfxdict = "scr_amb_chop", ptfxname = "ent_anim_dog_peeing", ptfxdelay = 300, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.1369101, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 40.0, ptfxrotz = 90.0, type = 2},
+    { dict = "switch@trevor@on_toilet", anim = "trev_on_toilet_loop", name = "Action: Take A Shit", flag = 47, ptfxdict = "scr_amb_chop", ptfxname = "ent_anim_dog_poo", ptfxdelay = 500, ptfxscale = 1.0, ptfxOffx = 0.2, ptfxOffy = -0.15, ptfxOffz = -0.1, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2},
+    { dict = "anim@move_f@grooving@", anim = "walk", name = "Movement: Goofy Walk", flag = 49},
+    { dict = "move_m@joy@a", anim = "walk", name = "Movement: Boss Walk", flag = 49},
+    { dict = "amb@world_human_jog_standing@female@idle_a", anim = "idle_a", name = "Movement: Goofy Run", flag = 49},
+    { dict = "anim@amb@nightclub@djs@solomun@", anim = "sol_sync_b_sol", name = "Activity: DJ 01 (Solomun)", prop1 = 2767137151, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx= 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 3, propColl = true, prop2 = 0},
+    { dict = "anim@amb@nightclub@djs@dixon@", anim = "dixn_sync_cntr_g_dix", name = "Activity: DJ 02 (Dixon)", prop1 = 2767137151, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx= 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 3, propColl = true, prop2 = 0},
+    { dict = "anim@amb@nightclub@djs@black_madonna@", anim = "pose_a_idle_e_blamadon", name = "Activity: DJ 03 (Black Madonna)", prop1 = 2767137151, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx= 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 3, propColl = true, prop2 = 0},
+    { dict = "mini@strip_club@idles@dj@idle_02", anim = "idle_02", name = "Activity: DJ 04", prop1 = 976772591, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 3, propColl = true, prop2 = 0},
+    { dict = "switch@franklin@press_ups", anim = "pressups_loop", name = "Activity: Push-ups", flag = 47},
+    { dict = "amb@world_human_sit_ups@male@base", anim = "base", name = "Activity: Sit-ups", flag = 47},
+    { dict = "anim@mp_player_intincarrockstd@ps@", anim = "idle_a", name = "Gesture: Metal", flag = 47},
+    { dict = "amb@world_human_stand_fishing@idle_a", anim = "idle_a", name = "Activity: Fishing", prop1 = 2384362703, boneID = 36029, posx = 0.1, posy = 0.08, posz = 0.03, rotx = 0, roty = 267, rotz = 230, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
+    { dict = "amb@world_human_stand_mobile@male@text@base", anim = "base", name = "MISC: Browse Phone", prop1 = 3083764787, boneID = 28422, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
     { dict = "amb@world_human_paparazzi@male@base", anim = "base", name = "MISC: Photograph", prop1 = 680380202, boneID = 28422, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "scr_bike_business", ptfxname = "scr_bike_cfid_camera_flash", ptfxdelay = 1000, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 5, propColl = true, prop2 = 0},
     { dict = "switch@trevor@jerking_off", anim = "trev_jerking_off_loop", name = "NSFW: Jerk off", prop1 = 3872089630, boneID = 64096, posx = 0.0053, posy = 0.02, posz = 0.01, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", type = 1, ptfxdelay = 0, ptfxscale = 0, propColl = true, prop2 = 0},
-    { dict = "mini@strip_club@private_dance@part2", anim = "priv_dance_p2", name = "NSFW: Lap Dance 01", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "mini@strip_club@private_dance@part3", anim = "priv_dance_p3", name = "NSFW: Lap Dance 02", prop1 = 3246457862, boneID = 12844, posx = -0.01, posy = 0.115, posz = -0.1, rotx = 0.0, roty = 0.0, rotz = 90.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, type = 1, prop2 = 0},
-    { dict = "switch@trevor@mocks_lapdance", anim = "001443_01_trvs_28_idle_stripper", name = "NSFW: Twerk", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "mini@prostitutes@sexlow_veh", anim = "low_car_sex_loop_female", name = "NSFW: Ride Dick In Car", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@mini@prostitutes@sex@veh_vstr@", anim = "bj_loop_prostitute", name = "NSFW: Give Head In Car", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@mini@prostitutes@sex@veh_vstr@", anim = "bj_loop_male", name = "NSFW: Receive Head In Car", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "misscarsteal2pimpsex", anim = "pimpsex_hooker", name = "NSFW: Give Head", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "rcmpaparazzo_2", anim = "shag_loop_a", name = "NSFW: Hit It From The Back 01", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "timetable@trevor@skull_loving_bear", anim = "skull_loving_bear", name = "NSFW: Hit It From The Back 02", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "timetable@trevor@skull_loving_bear", anim = "skull_loving_bear", name = "NSFW: Hit It From The Back 03", prop1 = 1022578470, boneID = 64096, posx = -0.069420, posy = -0.1, posz = -0.1, rotx = 32.0, roty = 50.0, rotz = 40.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0, type = 1},
-    { dict = "rcmpaparazzo_2", anim = "shag_loop_poppy", name = "NSFW: Take It From The Back", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "mp_player_int_uppergrab_crotch", anim = "mp_player_int_grab_crotch", name = "Action: Hold Your Nutts", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "mp_player_int_upperarse_pick", anim = "mp_player_int_arse_pick", name = "Action: Scratch Your Ass", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@scripted@ulp_missions@injured_agent@", anim = "idle_male", name = "Movement: Injured On The Ground", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "core", ptfxname = "ped_blood_drips", ptfxdelay = 100, ptfxscale = 10, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2, propColl = true, prop2 = 0},
-    { dict = "combat@damage@writheidle_a", anim = "writhe_idle_a", name = "Movement: Injured On The Ground 2", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "core", ptfxname = "ped_blood_drips", ptfxdelay = 100, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2, propColl = true, prop2 = 0},
-    { dict = "missminuteman_1ig_2", anim = "handsup_base", name = "Action: Hands Up", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "mp_missheist_countrybank@lift_hands", anim = "lift_hands_in_air_outro", name = "Action: Hands Up (static)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 50, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "nm@hands", anim = "flail", name = "Action: T-Pose", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 50, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "mp_defend_base", anim = "guard_handsup_loop", name = "Action: Hands Up Scared", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "missheist_agency2ahands_up", anim = "handsup_anxious", name = "Action: Hands Up Scared 2", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@mp_player_intupperjazz_hands", anim = "idle_a", name = "Action: Jazz Hands", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "random@arrests@busted", anim = "idle_a", name = "Action: Surrender 01", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "random@arrests@busted", anim = "idle_a", name = "Action: Surrender 02 (on your knees)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "veh@busted_bike@sport@", anim = "stay_in_car_crim", name = "Action: Surrender (sports bike)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 34, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "veh@busted_bike@chopper@", anim = "busted", name = "Action: Surrender (chopper bike)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 34, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "veh@busted_std", anim = "stay_in_car_crim", name = "Action: Surrender (regular car)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 34, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "veh@busted_low", anim = "stay_in_car_crim", name = "Action: Surrender (sports car)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 34, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "veh@busted_truck", anim = "stay_in_car_crim", name = "Action: Surrender (truck)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 34, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "veh@busted_van", anim = "stay_in_car_crim", name = "Action: Surrender (van)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 34, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "misscarsteal4@toilet", anim = "desperate_toilet_base_idle", name = "MISC: HAS TO PEE!", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 47, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "timetable@jimmy@doorknock@", anim = "knockdoor_idle", name = "Action: Knock On Door", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 51, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "move_m@_idles@shake_off", anim = "shakeoff_1", name = "Action: Shake Dirt Off Clothes", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 48, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "rcmnigel1c", anim = "hailing_whistle_waive_a", name = "Gesture: Whistle", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 48, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "friends@frj@ig_1", anim = "wave_a", name = "Gesture: Wave", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 48, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "random@car_thief@victimpoints_ig_3", anim = "arms_waving", name = "Gesture: Wave (both hands)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 48, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "gestures@m@standing@casual", anim = "gesture_hello", name = "Gesture: Wave (subtle)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 48, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "mp_ped_interaction", anim = "handshake_guy_b", name = "Gesture: Handshake 01", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 48, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "mp_ped_interaction", anim = "handshake_guy_a", name = "Gesture: Handshake 02", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 48, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@mp_player_intselfieblow_kiss", anim = "exit", name = "Gesture: Blow Kiss 01", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 48, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@mp_player_intcelebrationfemale@blow_kiss", anim = "blow_kiss", name = "Gesture: Blow Kiss 02", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 48, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_cheering@male_a", anim = "base", name = "Gesture: Clap", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@arena@celeb@flat@solo@no_props@", anim = "angry_clap_a_player_a", name = "Gesture: Clap Anrgy", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@mp_player_intupperslow_clap", anim = "idle_a", name = "Gesture: Clap Slowly", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@code_human_police_investigate@idle_a", anim = "idle_a", name = "Action: Police Investigate", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@code_human_police_investigate@idle_a", anim = "idle_b", name = "Action: Police Radio", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "melee@unarmed@streamed_variations", anim = "plyr_takedown_front_slap", name = "Action: Slap", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 0, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "melee@unarmed@streamed_variations", anim = "plyr_takedown_front_headbutt", name = "Action: Headbutt", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 0, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "rcmextreme2", anim = "loop_punching", name = "Activity: Boxing 01", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 48, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@mp_player_intuppershadow_boxing", anim = "idle_a", name = "Activity: Boxing 02", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "random@drunk_driver_1", anim = "drunk_fall_over", name = "Movement: Ragdoll (drunk)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 34, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "move_fall", anim = "land_fall", name = "Movement: Ragdoll", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 34, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "ragdoll@human", anim = "electrocute", name = "Movement: Ragdoll (tased)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 02, ptfxdict = "veh_xs_vehicle_mods", ptfxname = "veh_xs_electrified_rambar", ptfxdelay = 30, ptfxscale = 0.42069, ptfxOffx = 0.0, ptfxOffy = -1.5, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2, propColl = true, prop2 = 0},
-    { dict = "ragdoll@human", anim = "on_fire", name = "Movement: Ragdoll (on fire)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 02, ptfxdict = "core", ptfxname = "fire_wrecked_tank", ptfxdelay = 69, ptfxscale = 0.69420, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = -0.0069420, type = 2, propColl = true, prop2 = 0},
-    { dict = "anim@gangops@hostage@", anim = "victim_fail", name = "Movement: Ragdoll (shot in the head)", prop1 = 0, boneID = 12844, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 02, ptfxdict = "core", ptfxname = "ent_sht_blood", ptfxdelay = 200, ptfxscale = 0.5, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2, propColl = true, prop2 = 0},
-    { dict = "switch@michael@wash_face", anim = "loop_michael", name = "Action: Wash Face", prop1 = 0, boneID = 12844, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "core", ptfxname = "water_splash_ped_wade", ptfxdelay = 200, ptfxscale = 0.5, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2, propColl = true, prop2 = 0},
-    { dict = "anim@scripted@nightclub@vomit@", anim = "vomit", name = "Action: Vomit", prop1 = 0, boneID = 12844, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "scr_family5", ptfxname = "scr_trev_puke", ptfxdelay = 200, ptfxscale = 0.5, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2, propColl = true, prop2 = 0},
-    { dict = "amb@medic@standing@tendtodead@base", anim = "base", name = "Movement: Crouch", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@medic@standing@kneel@base", anim = "base", name = "Movement: Kneel", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "mp_ped_interaction", anim = "kisses_guy_a", name = "Action: Hug Lovingly <3", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 02, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_hang_out_street@female_arms_crossed@idle_a", anim = "idle_a", name = "MISC: Cross Arms", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "random@street_race", anim = "_car_b_lookout", name = "MISC: Cross Arms 02", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@mp_player_intupperface_palm", anim = "idle_a", name = "Gesture: Facepalm (-_-)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 48, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "misscarsteal4@aliens", anim = "rehearsal_base_idle_director", name = "Action: Think 01", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "missheist_jewelleadinout", anim = "jh_int_outro_loop_a", name = "Action: Think 02", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "mp_suicide", anim = "pill", name = "Action: Commit Seppuku (×_×) (pill)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 02, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "mp_suicide", anim = "pistol", name = "Action: Commit Seppuku (×_×) (pistol)", prop1 = 0, boneID = 12844, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 02, ptfxdict = "core", ptfxname = "ent_sht_blood", ptfxdelay = 800, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2, propColl = true, prop2 = 0},
-    { dict = "move_crawl", anim = "onfront_fwd", name = "Movement: Crawl Forward", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "move_injured_ground", anim = "sider_loop", name = "Movement: Crawl Forward (injured)", prop1 = 0, boneID = 12844, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "core", ptfxname = "ped_blood_drips", ptfxdelay = 30, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2, propColl = true, prop2 = 0},
-    { dict = "mp_player_int_uppergang_sign_a", anim = "mp_player_int_gang_sign_a_enter", name = "Gesture: Gang Sign 01", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 50, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "mp_player_int_uppergang_sign_b", anim = "mp_player_int_gang_sign_b_enter", name = "Gesture: Gang Sign 02", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 50, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@code_human_in_car_mp_actions@gang_sign_b@std@ps@base", anim = "idle_a", name = "Gesture: Gang Sign 03", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 50, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@code_human_in_car_mp_actions@gang_sign_a@bodhi@rps@base", anim = "idle_a", name = "Gesture: Gang Sign 04", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 50, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "mp_intro_seq@mcs_7_race_taunt", anim = "mcs_7_taunt_male", name = "Car: Race Taunt 01 (in-car)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 32, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "mp_intro_seq@mcs_7_race_taunt", anim = "mcs_7_taunt_female", name = "Car: Race Taunt 02 (in-car)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 32, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "missarmenian1driving_taunts@lamar_1", anim = "skoolinyoass", name = "Car: Race Taunt 03 (in-car)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 32, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "missarmenian1driving_taunts@lamar_1", anim = "keeppoping", name = "Car: Race Taunt 04 (in-car)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 32, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "missarmenian1driving_taunts@lamar_1", anim = "cmonmynigga", name = "Car: Race Taunt 05 (in-car)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 32, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "missarmenian1driving_taunts@franklin", anim = "ohyougotenginetrouble", name = "Car: Race Taunt 05 (in-car/roofless)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 32, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "random@street_race", anim = "grid_girl_race_start", name = "Car: Street Racing Countdown", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 32, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@amb@carmeet@checkout_car@", anim = "male_d_idle_d", name = "Car: Checkout Car", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 32, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@amb@carmeet@checkout_car@", anim = "male_h_base", name = "MISC: Arms On Sides", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@amb@carmeet@checkout_car@", anim = "male_f_idle_b", name = "MISC: Arms Front", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@amb@casino@valet_scenario@pose_d@", anim = "base_a_m_y_vinewood_01", name = "MISC: Arms Back", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "random@hitch_lift", anim = "idle_f", name = "Gesture: Hitch Hike", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "random@robbery", anim = "f_distressed_loop", name = "Action: Distressed", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "random@robbery", anim = "f_cower_02", name = "Action: Cower 01", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@code_human_cower@female@react_cowering", anim = "base_right", name = "Action: Cower 02", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "random@robbery", anim = "f_cower_01", name = "Action: Cry", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@veh@lowrider@low@front_ds@arm@base", anim = "shunt_from_left", name = "Car: Lean Left (in-car)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 34, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@veh@lowrider@low@front_ps@arm@base", anim = "lean_left_idle", name = "Car: Lean Right (in-car)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 34, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@arena@celeb@podium@no_prop@", anim = "regal_c_1st", name = "Gesture: Bow Down", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 0, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@amb@nightclub@mini@dance@dance_solo@shuffle@", anim = "high_center", name = "Activity: Dance 04", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "missbigscore2aig_7@gunman", anim = "boot_l_loop", name = "Action: Search Car Trunk", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@scripted@freemode@passed_out_vip_backseat_idle@male@", anim = "passed_out_vip_backseat_idle", name = "Car: Sleep In The Backseat (in-car)", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "random@car_thief@victim_points", anim = "point_l", name = "Gesture: Point To The Left", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 50, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "random@car_thief@victim_points", anim = "point_r", name = "Gesture: Point To The Right", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 50, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@amb@nightclub@mini@dance@dance_solo@jumper@", anim = "high_center", name = "Activity: Dance 05", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "rcmfanatic1out_of_breath", anim = "p_zero_tired_02", name = "Action: Out Of Breath 01", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "re@construction", anim = "out_of_breath", name = "Action: Out Of Breath 02", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 0, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@mp_player_intselfiethe_bird", anim = "idle_a", name = "Gesture: The Bird 01", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@mp_player_intupperfinger", anim = "idle_a_fp", name = "Gesture: The Bird 02", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "misscommon@response", anim = "screw_you", name = "Gesture: Up Yours!", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 48, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "misscommon@response", anim = "bring_it_on", name = "Gesture: Bring It On!", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 48, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "gestures@m@standing@casual", anim = "gesture_shrug_hard", name = "Gesture: Shrug", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 48, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "misscommon@response", anim = "damn", name = "Gesture: Damn!", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 48, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@mp_player_intincarsalutestd@ds@", anim = "idle_a", name = "Gesture: Salute 01", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "anim@mp_player_intuppersalute", anim = "idle_a", name = "Gesture: Salute 02", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "dead@fall", anim = "dead_fall_up", name = "Action: Levitate", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "dead@fall", anim = "dead_fall_down", name = "Action: Levitate Upside-Down", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "missmic2@meat_hook", anim = "michael_meat_hook_react_c", name = "Action: Hang Upside-Down", prop1 = 3005341058, boneID = 65245, posx = -0.018, posy = 0.1, posz = 0.15, rotx = -30.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 1, propColl = true, prop2 = 0},
-    { dict = "move_fall", anim = "land_roll", name = "Movement: Front Roll", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 32, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_hiker_standing@male@base", anim = "base", name = "Movement: Hiker 01", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_hiker_standing@male@base", anim = "base", name = "Movement: Hiker 02", prop1 = 2157846744, boneID = 24818, posx = -0.05, posy = -0.2, posz = 0.0, rotx = 0.0, roty = 90.0, rotz = -20.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0, type = 1},
-    { dict = "anim@scripted@ulp_missions@computerhack@heeled@", anim = "hacking_loop", name = "MISC: Hacker", prop1 = 3940780948, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0, type = 3},
-    { dict = "amb@world_human_bum_standing@depressed@idle_a", anim = "idle_b", name = "Action: Sad", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_bum_standing@depressed@idle_a", anim = "idle_a", name = "Action: Depressed", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "amb@world_human_stand_fire@male@idle_a", anim = "idle_a", name = "Action: Stand Around Camp Fire", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0},
-    { dict = "rcmjosh2", anim = "josh_2_intp1_base", name = "MISC: Ghost Girlfriend", prop1 = 3270826173, boneID = 60309, posx = 1.4, posy = 0.0, posz = 0.12, rotx = 90.0, roty = -5.0, rotz = -90.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0, type = 1},
-    { dict = "rcmjosh2", anim = "josh_2_intp1_base", name = "MISC: Ghost Boyfriend", prop1 = 2932993356, boneID = 60309, posx = 1.5, posy = 0.0, posz = 0.15, rotx = 90.0, roty = -5.0, rotz = -90.0, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0, type = 1},
-    { dict = "amb@medic@standing@kneel@idle_a", anim = "idle_b", name = "Action: Crime Scene Medic", prop1 = 3026386862, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = -0.0, rotz = 20.0, flag = 1, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0, type = 3},
-    { dict = "amb@code_human_police_investigate@idle_a", anim = "idle_a", name = "Action: Crime Scene Investigator", prop1 = 3026386862, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 20.0, flag = 1, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0, type = 3},
-    { dict = "amb@world_human_clipboard@male@base", anim = "base", name = "NSFW: Porn Magazine 01", prop1 = 2727617608, boneID = 60309, posx = 0.08, posy = -0.049, posz = -0.05, rotx = 87.9369, roty = -0.4292, rotz = -14.3925, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0, type = 1},
-    { dict = "amb@world_human_clipboard@male@base", anim = "base", name = "NSFW: Porn Magazine 02", prop1 = 3306343310, boneID = 60309, posx = 0.12, posy = -0.049, posz = -0.05, rotx = 87.9369, roty = -0.4292, rotz = -14.3925, flag = 49, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0, type = 1},
+    { dict = "mini@strip_club@private_dance@part2", anim = "priv_dance_p2", name = "NSFW: Lap Dance 01", flag = 47},
+    { dict = "mini@strip_club@private_dance@part3", anim = "priv_dance_p3", name = "NSFW: Lap Dance 02", prop1 = 3246457862, boneID = 12844, posx = -0.01, posy = 0.115, posz = -0.1, rotx = 0.0, roty = 0.0, rotz = 90.0, flag = 47, type = 1},
+    { dict = "switch@trevor@mocks_lapdance", anim = "001443_01_trvs_28_idle_stripper", name = "NSFW: Twerk", flag = 47},
+    { dict = "mini@prostitutes@sexlow_veh", anim = "low_car_sex_loop_female", name = "NSFW: Ride Dick In Car", flag = 47},
+    { dict = "anim@mini@prostitutes@sex@veh_vstr@", anim = "bj_loop_prostitute", name = "NSFW: Give Head In Car", flag = 47},
+    { dict = "anim@mini@prostitutes@sex@veh_vstr@", anim = "bj_loop_male", name = "NSFW: Receive Head In Car", flag = 47},
+    { dict = "misscarsteal2pimpsex", anim = "pimpsex_hooker", name = "NSFW: Give Head", flag = 47},
+    { dict = "rcmpaparazzo_2", anim = "shag_loop_a", name = "NSFW: Hit It From The Back 01", flag = 47, type = 7, boneID = 0, pedType = "PED_TYPE_CIVFEMALE", pedHash = 1846523796, posx = 0.0, posy = 0.2, posz = 0.0, rotx  = 40.0, roty = 0.0, rotz = 0.0, dict2 = "rcmpaparazzo_2", anim2 = "shag_loop_poppy"},
+    { dict = "timetable@trevor@skull_loving_bear", anim = "skull_loving_bear", name = "NSFW: Hit It From The Back 02", prop1 = 1022578470, boneID = 64096, posx = -0.069420, posy = -0.1, posz = -0.1, rotx = 32.0, roty = 50.0, rotz = 40.0, flag = 47, type = 1},
+    { dict = "misscarsteal2pimpsex", anim = "shagloop_pimp", name = "NSFW: Hit It From The Front", flag = 47, type = 7, boneID = 0, pedType = "PED_TYPE_CIVFEMALE", pedHash = 1846523796, posx = 0.05, posy = 0.3, posz = -0.2, rotx  = 27.0, roty = 0.0, rotz = 190.0, dict2 = "misscarsteal2pimpsex", anim2 = "shagloop_hooker"},
+    { dict = "misscarsteal2pimpsex", anim = "shagloop_hooker", name = "NSFW: Take It From The Front", flag = 47},
+    { dict = "rcmpaparazzo_2", anim = "shag_loop_poppy", name = "NSFW: Take It From The Back", flag = 47},
+    { dict = "mp_player_int_uppergrab_crotch", anim = "mp_player_int_grab_crotch", name = "Action: Hold Your Nutts", flag = 49},
+    { dict = "mp_player_int_upperarse_pick", anim = "mp_player_int_arse_pick", name = "Action: Scratch Your Ass", flag = 49},
+    { dict = "anim@scripted@ulp_missions@injured_agent@", anim = "idle_male", name = "Movement: Injured On The Ground", flag = 47, ptfxdict = "core", ptfxname = "ped_blood_drips", ptfxdelay = 100, ptfxscale = 10, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2},
+    { dict = "combat@damage@writheidle_a", anim = "writhe_idle_a", name = "Movement: Injured On The Ground 2", flag = 47, ptfxdict = "core", ptfxname = "ped_blood_drips", ptfxdelay = 100, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2},
+    { dict = "missminuteman_1ig_2", anim = "handsup_base", name = "Action: Hands Up", flag = 49},
+    { dict = "mp_missheist_countrybank@lift_hands", anim = "lift_hands_in_air_outro", name = "Action: Hands Up (static)", flag = 50},
+    { dict = "nm@hands", anim = "flail", name = "Action: T-Pose", flag = 50},
+    { dict = "mp_defend_base", anim = "guard_handsup_loop", name = "Action: Hands Up Scared", flag = 49},
+    { dict = "missheist_agency2ahands_up", anim = "handsup_anxious", name = "Action: Hands Up Scared 2", flag = 49},
+    { dict = "anim@mp_player_intupperjazz_hands", anim = "idle_a", name = "Action: Jazz Hands", flag = 49},
+    { dict = "random@arrests@busted", anim = "idle_a", name = "Action: Surrender 01", flag = 49},
+    { dict = "random@arrests@busted", anim = "idle_a", name = "Action: Surrender 02 (on your knees)", flag = 47},
+    { dict = "veh@busted_bike@sport@", anim = "stay_in_car_crim", name = "Action: Surrender (sports bike)", flag = 34},
+    { dict = "veh@busted_bike@chopper@", anim = "busted", name = "Action: Surrender (chopper bike)", flag = 34},
+    { dict = "veh@busted_std", anim = "stay_in_car_crim", name = "Action: Surrender (regular car)", flag = 34},
+    { dict = "veh@busted_low", anim = "stay_in_car_crim", name = "Action: Surrender (sports car)", flag = 34},
+    { dict = "veh@busted_truck", anim = "stay_in_car_crim", name = "Action: Surrender (truck)", flag = 34},
+    { dict = "veh@busted_van", anim = "stay_in_car_crim", name = "Action: Surrender (van)", flag = 34},
+    { dict = "misscarsteal4@toilet", anim = "desperate_toilet_base_idle", name = "MISC: HAS TO PEE!", flag = 47},
+    { dict = "timetable@jimmy@doorknock@", anim = "knockdoor_idle", name = "Action: Knock On Door", flag = 51},
+    { dict = "move_m@_idles@shake_off", anim = "shakeoff_1", name = "Action: Shake Dirt Off Clothes", flag = 48},
+    { dict = "rcmnigel1c", anim = "hailing_whistle_waive_a", name = "Gesture: Whistle", flag = 48},
+    { dict = "friends@frj@ig_1", anim = "wave_a", name = "Gesture: Wave", flag = 48},
+    { dict = "random@car_thief@victimpoints_ig_3", anim = "arms_waving", name = "Gesture: Wave (both hands)", flag = 48},
+    { dict = "gestures@m@standing@casual", anim = "gesture_hello", name = "Gesture: Wave (subtle)", flag = 48},
+    { dict = "mp_ped_interaction", anim = "handshake_guy_b", name = "Gesture: Handshake 01", flag = 48},
+    { dict = "mp_ped_interaction", anim = "handshake_guy_a", name = "Gesture: Handshake 02", flag = 48},
+    { dict = "anim@mp_player_intselfieblow_kiss", anim = "exit", name = "Gesture: Blow Kiss 01", flag = 48},
+    { dict = "anim@mp_player_intcelebrationfemale@blow_kiss", anim = "blow_kiss", name = "Gesture: Blow Kiss 02", flag = 48},
+    { dict = "amb@world_human_cheering@male_a", anim = "base", name = "Gesture: Clap", flag = 49},
+    { dict = "anim@arena@celeb@flat@solo@no_props@", anim = "angry_clap_a_player_a", name = "Gesture: Clap (anrgy)", flag = 49},
+    { dict = "anim@mp_player_intupperslow_clap", anim = "idle_a", name = "Gesture: Clap (slow)", flag = 49},
+    { dict = "amb@code_human_police_investigate@idle_a", anim = "idle_a", name = "Action: Police Investigate", flag = 49},
+    { dict = "amb@code_human_police_investigate@idle_a", anim = "idle_b", name = "Action: Police Radio", flag = 49},
+    { dict = "melee@unarmed@streamed_variations", anim = "plyr_takedown_front_slap", name = "Action: Slap", flag = 0},
+    { dict = "melee@unarmed@streamed_variations", anim = "plyr_takedown_front_headbutt", name = "Action: Headbutt", flag = 0},
+    { dict = "rcmextreme2", anim = "loop_punching", name = "Activity: Boxing 01", flag = 48},
+    { dict = "anim@mp_player_intuppershadow_boxing", anim = "idle_a", name = "Activity: Boxing 02", flag = 49},
+    { dict = "random@drunk_driver_1", anim = "drunk_fall_over", name = "Movement: Ragdoll (drunk)", flag = 34},
+    { dict = "move_fall", anim = "land_fall", name = "Movement: Ragdoll", flag = 34},
+    { dict = "ragdoll@human", anim = "electrocute", name = "Movement: Ragdoll (tased)", flag = 02, ptfxdict = "veh_xs_vehicle_mods", ptfxname = "veh_xs_electrified_rambar", ptfxdelay = 30, ptfxscale = 0.42069, ptfxOffx = 0.0, ptfxOffy = -1.5, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2},
+    { dict = "ragdoll@human", anim = "on_fire", name = "Movement: Ragdoll (on fire)", flag = 02, ptfxdict = "core", ptfxname = "fire_wrecked_tank", ptfxdelay = 69, ptfxscale = 0.69420, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = -0.0069420, type = 2},
+    { dict = "anim@gangops@hostage@", anim = "victim_fail", name = "Movement: Ragdoll (shot in the head)", prop1 = 0, boneID = 12844, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 02, ptfxdict = "core", ptfxname = "ent_sht_blood", ptfxdelay = 200, ptfxscale = 0.5, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2},
+    { dict = "dead", anim = "dead_e", name = "Action: Dead 01", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 02, ptfxdict = "core", ptfxname = "ent_sht_blood", ptfxdelay = 400, ptfxscale = 0.2, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2, propColl = true, prop2 = 0},
+    { dict = "dead", anim = "dead_f", name = "Action: Dead 02", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 02, ptfxdict = "core", ptfxname = "ent_sht_blood", ptfxdelay = 400, ptfxscale = 0.2, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2, propColl = true, prop2 = 0},
+    { dict = "dead", anim = "dead_d", name = "Action: Dead 03", prop1 = 0, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 02, ptfxdict = "core", ptfxname = "ent_sht_blood", ptfxdelay = 400, ptfxscale = 0.2, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2, propColl = true, prop2 = 0},
+    { dict = "switch@michael@wash_face", anim = "loop_michael", name = "Action: Wash Face", prop1 = 0, boneID = 12844, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "core", ptfxname = "water_splash_ped_wade", ptfxdelay = 200, ptfxscale = 0.5, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2},
+    { dict = "anim@scripted@nightclub@vomit@", anim = "vomit", name = "Action: Vomit", prop1 = 0, boneID = 12844, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 49, ptfxdict = "scr_family5", ptfxname = "scr_trev_puke", ptfxdelay = 200, ptfxscale = 0.5, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2},
+    { dict = "amb@medic@standing@tendtodead@base", anim = "base", name = "Movement: Crouch", flag = 33},
+    { dict = "amb@medic@standing@kneel@base", anim = "base", name = "Movement: Kneel", flag = 33},
+    { dict = "mp_ped_interaction", anim = "kisses_guy_a", name = "Action: Hug Lovingly <3", flag = 02},
+    { dict = "amb@world_human_hang_out_street@female_arms_crossed@idle_a", anim = "idle_a", name = "MISC: Cross Arms", flag = 49},
+    { dict = "random@street_race", anim = "_car_b_lookout", name = "MISC: Cross Arms 02", flag = 49},
+    { dict = "anim@mp_player_intupperface_palm", anim = "idle_a", name = "Gesture: Facepalm (-_-)", flag = 48},
+    { dict = "misscarsteal4@aliens", anim = "rehearsal_base_idle_director", name = "Action: Think 01", flag = 49},
+    { dict = "missheist_jewelleadinout", anim = "jh_int_outro_loop_a", name = "Action: Think 02", flag = 49},
+    { dict = "mp_suicide", anim = "pill", name = "Action: Commit Seppuku (×_×) (pill)", flag = 02},
+    { dict = "mp_suicide", anim = "pistol", name = "Action: Commit Seppuku (×_×) (pistol)", prop1 = 0, boneID = 12844, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 02, ptfxdict = "core", ptfxname = "ent_sht_blood", ptfxdelay = 800, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2},
+    { dict = "move_crawl", anim = "onfront_fwd", name = "Movement: Crawl Forward", flag = 33},
+    { dict = "move_injured_ground", anim = "sider_loop", name = "Movement: Crawl Forward (injured)", prop1 = 0, boneID = 12844, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, ptfxdict = "core", ptfxname = "ped_blood_drips", ptfxdelay = 30, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, type = 2},
+    { dict = "mp_player_int_uppergang_sign_a", anim = "mp_player_int_gang_sign_a_enter", name = "Gesture: Gang Sign 01", flag = 50},
+    { dict = "mp_player_int_uppergang_sign_b", anim = "mp_player_int_gang_sign_b_enter", name = "Gesture: Gang Sign 02", flag = 50},
+    { dict = "amb@code_human_in_car_mp_actions@gang_sign_b@std@ps@base", anim = "idle_a", name = "Gesture: Gang Sign 03", flag = 50},
+    { dict = "amb@code_human_in_car_mp_actions@gang_sign_a@bodhi@rps@base", anim = "idle_a", name = "Gesture: Gang Sign 04", flag = 50},
+    { dict = "mp_intro_seq@mcs_7_race_taunt", anim = "mcs_7_taunt_male", name = "Car: Race Taunt 01 (in-car)", flag = 32},
+    { dict = "mp_intro_seq@mcs_7_race_taunt", anim = "mcs_7_taunt_female", name = "Car: Race Taunt 02 (in-car)", flag = 32},
+    { dict = "missarmenian1driving_taunts@lamar_1", anim = "skoolinyoass", name = "Car: Race Taunt 03 (in-car)", flag = 32},
+    { dict = "missarmenian1driving_taunts@lamar_1", anim = "keeppoping", name = "Car: Race Taunt 04 (in-car)", flag = 32},
+    { dict = "missarmenian1driving_taunts@lamar_1", anim = "cmonmynigga", name = "Car: Race Taunt 05 (in-car)", flag = 32},
+    { dict = "missarmenian1driving_taunts@franklin", anim = "ohyougotenginetrouble", name = "Car: Race Taunt 05 (in-car/roofless)", flag = 32},
+    { dict = "random@street_race", anim = "grid_girl_race_start", name = "Car: Street Racing Countdown", flag = 32},
+    { dict = "anim@amb@carmeet@checkout_car@", anim = "male_d_idle_d", name = "Car: Checkout Car", flag = 32},
+    { dict = "missheat", anim = "guard_dead_ps", name = "Car: Dead 01 (in-car)",flag = 18},
+    { dict = "missmic3leadinout_mcs1", anim = "cockpit_pilot", name = "Car: Dead 02 (in-car)", flag = 18},
+    { dict = "anim@amb@carmeet@checkout_car@", anim = "male_h_base", name = "MISC: Arms On Sides", flag = 49},
+    { dict = "anim@amb@carmeet@checkout_car@", anim = "male_f_idle_b", name = "MISC: Arms Front", flag = 49},
+    { dict = "anim@amb@casino@valet_scenario@pose_d@", anim = "base_a_m_y_vinewood_01", name = "MISC: Arms Back", flag = 49},
+    { dict = "random@hitch_lift", anim = "idle_f", name = "Gesture: Hitch Hike", flag = 49},
+    { dict = "random@robbery", anim = "f_distressed_loop", name = "Action: Distressed", flag = 33},
+    { dict = "random@robbery", anim = "f_cower_02", name = "Action: Cower 01", flag = 33},
+    { dict = "amb@code_human_cower@female@react_cowering", anim = "base_right", name = "Action: Cower 02", flag = 33},
+    { dict = "random@robbery", anim = "f_cower_01", name = "Action: Cry", flag = 33},
+    { dict = "anim@veh@lowrider@low@front_ds@arm@base", anim = "shunt_from_left", name = "Car: Lean Left (in-car)", flag = 34},
+    { dict = "anim@veh@lowrider@low@front_ps@arm@base", anim = "lean_left_idle", name = "Car: Lean Right (in-car)", flag = 34},
+    { dict = "anim@arena@celeb@podium@no_prop@", anim = "regal_c_1st", name = "Gesture: Bow Down", flag = 0},
+    { dict = "anim@amb@nightclub@mini@dance@dance_solo@shuffle@", anim = "high_center", name = "Activity: Dance 04", flag = 33},
+    { dict = "missbigscore2aig_7@gunman", anim = "boot_l_loop", name = "Action: Search Car Trunk", flag = 33},
+    { dict = "anim@scripted@freemode@passed_out_vip_backseat_idle@male@", anim = "passed_out_vip_backseat_idle", name = "Car: Sleep In The Backseat (in-car)", flag = 33},
+    { dict = "random@car_thief@victim_points", anim = "point_l", name = "Gesture: Point To The Left", 50},
+    { dict = "random@car_thief@victim_points", anim = "point_r", name = "Gesture: Point To The Right", flag = 50},
+    { dict = "anim@amb@nightclub@mini@dance@dance_solo@jumper@", anim = "high_center", name = "Activity: Dance 05", flag = 33},
+    { dict = "rcmfanatic1out_of_breath", anim = "p_zero_tired_02", name = "Action: Out Of Breath 01", flag = 49},
+    { dict = "re@construction", anim = "out_of_breath", name = "Action: Out Of Breath 02", flag = 0},
+    { dict = "anim@mp_player_intselfiethe_bird", anim = "idle_a", name = "Gesture: The Bird 01", flag = 49},
+    { dict = "anim@mp_player_intupperfinger", anim = "idle_a_fp", name = "Gesture: The Bird 02", flag = 49},
+    { dict = "misscommon@response", anim = "screw_you", name = "Gesture: Up Yours!", flag = 48},
+    { dict = "anim@scripted@cbr3@ig1_vehicle_trunk_reaction@heeled@", anim = "trunk_negative_reaction", name = "Gesture: Disapprove", flag = 48},
+    { dict = "anim@scripted@cbr3@ig1_vehicle_trunk_reaction@heeled@", anim = "trunk_positive_reaction", name = "Gesture: Approve", flag = 48},
+    { dict = "misscommon@response", anim = "bring_it_on", name = "Gesture: Bring It On!", flag = 48},
+    { dict = "gestures@m@standing@casual", anim = "gesture_shrug_hard", name = "Gesture: Shrug", flag = 48},
+    { dict = "misscommon@response", anim = "damn", name = "Gesture: Damn!", flag = 48},
+    { dict = "anim@mp_player_intincarsalutestd@ds@", anim = "idle_a", name = "Gesture: Salute 01", flag = 49},
+    { dict = "anim@mp_player_intuppersalute", anim = "idle_a", name = "Gesture: Salute 02", flag = 49},
+    { dict = "dead@fall", anim = "dead_fall_up", name = "Action: Levitate", flag = 33},
+    { dict = "dead@fall", anim = "dead_fall_down", name = "Action: Levitate Upside-Down", flag = 33},
+    { dict = "missmic2@meat_hook", anim = "michael_meat_hook_react_c", name = "Action: Hang Upside-Down", prop1 = 3005341058, boneID = 65245, posx = -0.018, posy = 0.1, posz = 0.15, rotx = -30.0, roty = 0.0, rotz = 0.0, flag = 33, type = 1},
+    { dict = "move_fall", anim = "land_roll", name = "Movement: Front Roll", flag = 32},
+    { dict = "amb@world_human_hiker_standing@male@base", anim = "base", name = "Movement: Hiker 01", flag = 49},
+    { dict = "amb@world_human_hiker_standing@male@base", anim = "base", name = "Movement: Hiker 02", prop1 = 2157846744, boneID = 24818, posx = -0.05, posy = -0.2, posz = 0.0, rotx = 0.0, roty = 90.0, rotz = -20.0, flag = 49, type = 1},
+    { dict = "anim@scripted@ulp_missions@computerhack@heeled@", anim = "hacking_loop", name = "MISC: Hacker", prop1 = 3940780948, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0, flag = 33, type = 3},
+    { dict = "amb@world_human_bum_standing@depressed@idle_a", anim = "idle_b", name = "Action: Sad", flag = 33},
+    { dict = "amb@world_human_bum_standing@depressed@idle_a", anim = "idle_a", name = "Action: Depressed", flag = 33},
+    { dict = "amb@world_human_stand_fire@male@idle_a", anim = "idle_a", name = "Action: Stand Around Camp Fire", flag = 33},
+    { dict = "rcmjosh2", anim = "josh_2_intp1_base", name = "MISC: Ghost Girlfriend", prop1 = 3270826173, boneID = 60309, posx = 1.4, posy = 0.0, posz = 0.12, rotx = 90.0, roty = -5.0, rotz = -90.0, flag = 49, type = 1},
+    { dict = "rcmjosh2", anim = "josh_2_intp1_base", name = "MISC: Ghost Boyfriend", prop1 = 2932993356, boneID = 60309, posx = 1.5, posy = 0.0, posz = 0.15, rotx = 90.0, roty = -5.0, rotz = -90.0, flag = 49, type = 1},
+    { dict = "amb@medic@standing@kneel@idle_a", anim = "idle_b", name = "Action: Crime Scene Medic", prop1 = 3026386862, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = -0.0, rotz = 20.0, flag = 1, type = 3},
+    { dict = "amb@code_human_police_investigate@idle_a", anim = "idle_a", name = "Action: Crime Scene Investigator", prop1 = 3026386862, boneID = 0, posx = 0.0, posy = 0.0, posz = 0.0, rotx = 0.0, roty = 0.0, rotz = 20.0, flag = 1, type = 3},
+    { dict = "amb@world_human_clipboard@male@base", anim = "base", name = "NSFW: Porn Magazine 01", prop1 = 2727617608, boneID = 60309, posx = 0.08, posy = -0.049, posz = -0.05, rotx = 87.9369, roty = -0.4292, rotz = -14.3925, flag = 49, type = 1},
+    { dict = "amb@world_human_clipboard@male@base", anim = "base", name = "NSFW: Porn Magazine 02", prop1 = 3306343310, boneID = 60309, posx = 0.12, posy = -0.049, posz = -0.05, rotx = 87.9369, roty = -0.4292, rotz = -14.3925, flag = 49, type = 1},
     { dict = "missheistdockssetup1clipboard@base", anim = "base", name = "MISC: Clipboard", prop1 = 2896824542, boneID = 60309, posx = 0.011, posy = 0.007, posz = -0.02, rotx = 96.2, roty = 0.0, rotz = 0.0, flag = 49, prop2 = 463086472, bone2 = 58867, posx2 = 0.05, posy2 = -0.01, posz2 = -0.01, rotx2 = 0.0, roty2 = 0.0, rotz2 = 0.0, type = 6},
-    { dict = "amb@incar@male@patrol@torch@idle_a", anim = "idle_a", name = "Car: Police Torch (in-car)", prop1 = 211760048, boneID = 28422, posx = 0.0, posy = -0.009, posz = -0.01, rotx = 0.0, roty = 0.0, rotz = 90.0, flag = 33, ptfxdict = "", ptfxname = "", ptfxdelay = 0, ptfxscale = 1.0, ptfxOffx = 0.0, ptfxOffy = 0.0, ptfxOffz = 0.0, ptfxrotx = 0.0, ptfxroty = 0.0, ptfxrotz = 0.0, propColl = true, prop2 = 0, type = 1},
+    { dict = "amb@incar@male@patrol@torch@idle_a", anim = "idle_a", name = "Car: Police Torch (in-car)", prop1 = 211760048, boneID = 28422, posx = 0.0, posy = -0.009, posz = -0.01, rotx = 0.0, roty = 0.0, rotz = 90.0, flag = 33, type = 1},
 }
 
 ped_scenarios = {
@@ -2536,6 +2544,7 @@ ped_scenarios = {
     {scenario = "WORLD_HUMAN_TOURIST_MOBILE", name = "Take Photo"},
     {scenario = "PROP_HUMAN_ATM", name = "Use ATM"},
     {scenario = "WORLD_HUMAN_VALET", name = "Valet"},
+    {scenario = "WORLD_VEHICLE_BROKEN_DOWN", name = "Vehicle Broken (must be in a vehicle)"},
     {scenario = "PROP_HUMAN_SEAT_BUS_STOP_WAIT", name = "Wait At Bus Stop"},
     {scenario = "PROP_HUMAN_SEAT_STRIP_WATCH", name = "Watch Stripper"},
     {scenario = "WORLD_HUMAN_WINDOW_SHOP_BROWSE", name = "Window Shop"},
@@ -2546,3 +2555,318 @@ ped_scenarios = {
     {scenario = "WORLD_HUMAN_SIT_UPS", name = "Workout: Sit-ups"},
     {scenario = "WORLD_HUMAN_YOGA", name = "Workout: Yoga"},
 }
+
+npcList = {
+    {group = "PED_TYPE_CIVFEMALE", hash = 0x6E0FB794, name = "Hooker"},
+    {group = "PED_TYPE_CIVFEMALE", hash = 0x52580019, name = "Hooker 02"},
+    {group = "PED_TYPE_CIVFEMALE", hash = 0x780C01BD, name = "VU Bartender"},
+    {group = "PED_TYPE_CIVMALE", hash = 0x5442C66B, name = "Cult Fat Man"},
+    {group = "PED_TYPE_CIVMALE", hash = 0x55446010, name = "Cult Old Man"},
+    {group = "PED_TYPE_CIVMALE", hash = 0xCF0C7037, name = "DRE"},
+    {group = "PED_TYPE_CIVMALE", hash = 0x69287899, name = "Vincent"},
+    {group = "PED_TYPE_CIVMALE", hash = 0x65B93076, name = "Lamar"},
+    {group = "PED_TYPE_CIVMALE", hash = 0xCE2CB751, name = "JEEBUS"},
+    {group = "PED_TYPE_CIVMALE", hash = 0xA17EC96C, name = "Yusuf Amir"},
+    {group = "PED_TYPE_CIVMALE", hash = 0x8CE6A476, name = "Yeti"},
+    {group = "PED_TYPE_CIVFEMALE", hash = 0xB5CF80E4, name = "Cult Fat Woman"},
+    {group = "PED_TYPE_CIVFEMALE", hash = 0x3BD99114, name = "Muscle Woman"},
+    {group = "PED_TYPE_CIVMALE", hash = 0x4B652906, name = "Muscle Man"},
+    {group = "PED_TYPE_CIVFEMALE", hash = 0x51D861F2, name = "Luchadora"},
+    {group = "PED_TYPE_ANIMAL", hash = 0xCE5FF074, name = "Boar"},
+    {group = "PED_TYPE_ANIMAL", hash = 0x4E8F95A2, name = "Husky"},
+    {group = "PED_TYPE_ANIMAL", hash = 0x14EC17EA, name = "Chop"},
+    {group = "PED_TYPE_ANIMAL", hash = 0x7E0C64AA, name = "Monkey"},
+    {group = "PED_TYPE_ANIMAL", hash = 0xC2D06F53, name = "Monkey 02"},
+    {group = "PED_TYPE_ANIMAL", hash = 0xB11BAB56, name = "Pig"},
+    {group = "PED_TYPE_ANIMAL", hash = 0xFCFA9E1E, name = "Cow"},
+    {group = "PED_TYPE_ANIMAL", hash = 0xC3B52966, name = "Rat"},
+    {group = "PED_TYPE_ARMY", hash = 0xB3F3EE34, name = "Mercenary 01"},
+    {group = "PED_TYPE_ARMY", hash = 0x5076A73B, name = "Mercenary 02"},
+    {group = "PED_TYPE_COP", hash = 0x15F8700D, name = "Police (female)"},
+    {group = "PED_TYPE_COP", hash = 0x5E3DA4A4, name = "Police (male)"},
+    {group = "PED_TYPE_COP", hash = 0x8D8F1B10, name = "Police (SWAT)"},
+    {group = "PED_TYPE_CIVFEMALE", hash = 0x7671A8F6, name = "Imani"},
+    {group = "PED_TYPE_CIVMALE", hash = 0x4DA6E849, name = "Lester"},
+    {group = "PED_TYPE_CIVMALE", hash = 0x9B810FA2, name = "Trevor"},
+    {group = "PED_TYPE_CIVMALE", hash = 0xD7114C9, name = "Michael"},
+    {group = "PED_TYPE_CIVMALE", hash = 0x9B22DBAF, name = "Franklin"},
+    {group = "PED_TYPE_CIVMALE", hash = 0x842DC2D6, name = "Jimmy"},
+    {group = "PED_TYPE_CIVFEMALE", hash = 0x6D1E15F7, name = "Amanda"},
+    {group = "PED_TYPE_CIVMALE", hash = 0xEC9E8F1C, name = "Hao"},
+    {group = "PED_TYPE_CIVMALE", hash = 0x7461A0B0, name = "Devin Weston"},
+    {group = "PED_TYPE_CIVFEMALE", hash = 0xDE352A35, name = "Tracy"},
+    {group = "PED_TYPE_CIVFEMALE", hash = 0x2D145A18, name = "Agatha Baker"},
+    {group = "PED_TYPE_CIVMALE", hash = 0x86BDFE26, name = "Solomun Richards"},
+    {group = "PED_TYPE_CIVMALE", hash = 0x9B557274, name = "Personal Bodyguard"},
+    {group = "PED_TYPE_CIVMALE", hash = 0x850446EC, name = "Lazlow"},
+    {group = "PED_TYPE_CIVMALE", hash = 0xE80E9160, name = "Brucie Kibbutz"},
+}
+
+function Button(text, color, hovercolor, activecolor)
+    ImGui.PushStyleColor(ImGuiCol.Button, color[1]/255, color[2]/255, color[3]/255, color[4])
+    ImGui.PushStyleColor(ImGuiCol.ButtonHovered, hovercolor[1]/255, hovercolor[2]/255, hovercolor[3]/255, hovercolor[4])
+    ImGui.PushStyleColor(ImGuiCol.ButtonActive, activecolor[1]/255, activecolor[2]/255, activecolor[3]/255, activecolor[4])
+    local retval = ImGui.Button(text)
+    ImGui.PopStyleColor(3)
+    return retval
+end
+
+function coloredText(text, color)
+    ImGui.PushStyleColor(ImGuiCol.Text, color[1]/255, color[2]/255, color[3]/255, color[4])
+    ImGui.PushTextWrapPos(ImGui.GetFontSize() * 20)
+    ImGui.TextWrapped(text)
+    ImGui.PushTextWrapPos(ImGui.GetFontSize() * 20)
+    ImGui.PopStyleColor(1)
+end
+
+function busyspinner(text, type)
+    HUD.BEGIN_TEXT_COMMAND_BUSYSPINNER_ON("STRING")
+    HUD.ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME(text)
+    HUD.END_TEXT_COMMAND_BUSYSPINNER_ON(type)
+end
+
+function helpmarker(colorFlag, text, color)
+    ImGui.SameLine()
+    ImGui.TextDisabled("(?)")
+    if ImGui.IsItemHovered() then
+        ImGui.SetNextWindowBgAlpha(0.75)
+        ImGui.BeginTooltip()
+        if colorFlag == true then
+            coloredText(text, color)
+        else
+            ImGui.PushTextWrapPos(ImGui.GetFontSize() * 20)
+            ImGui.TextWrapped(text)
+            ImGui.PopTextWrapPos()
+        end
+        ImGui.EndTooltip()
+	end
+end
+
+function widgetToolTip(colorFlag, text, color)
+    if ImGui.IsItemHovered() then
+        ImGui.SetNextWindowBgAlpha(0.75)
+        ImGui.BeginTooltip()
+        if colorFlag == true then
+            coloredText(text, color)
+        else
+            ImGui.PushTextWrapPos(ImGui.GetFontSize() * 20)
+            ImGui.TextWrapped(text)
+            ImGui.PopTextWrapPos()
+        end
+        ImGui.EndTooltip()
+	end
+end
+
+function RequestControl(entity, netID, ticks)
+    local tick = 0
+    ticks = ticks or 50
+    script.run_in_fiber(function()
+        NETWORK.SET_NETWORK_ID_CAN_MIGRATE(netID, true)
+        while not NETWORK.NETWORK_HAS_CONTROL_OF_ENTITY(entity) and tick < ticks do
+            NETWORK.NETWORK_REQUEST_CONTROL_OF_ENTITY(entity)
+            tick = tick + 1
+        end
+        return NETWORK.NETWORK_HAS_CONTROL_OF_ENTITY(entity), tick
+    end)
+end
+
+function entToNet(entity, netID)
+    script.run_in_fiber(function()
+        if NETWORK.NETWORK_HAS_CONTROL_OF_NETWORK_ID(netID) then
+            NETWORK.SET_NETWORK_ID_EXISTS_ON_ALL_MACHINES(netID)
+            NETWORK.SET_NETWORK_ID_VISIBLE_IN_CUTSCENE(netID, false, true)
+            NETWORK.NETWORK_SET_ENTITY_ONLY_EXISTS_FOR_PARTICIPANTS(entity, false)
+            NETWORK.SET_NETWORK_ID_ALWAYS_EXISTS_FOR_PLAYER(netID, ped, true)
+            NETWORK.SET_NETWORK_ID_CAN_MIGRATE(netID, false)
+        end
+    end)
+end
+
+function playSelected(target, propPed, targetBone, targetCoords, targetHeading, targetForwardX, targetForwardY, targetBoneCoords)
+    if info.type == 1 then
+        cleanup()
+        script.run_in_fiber(function()
+            if not disableProps then
+                while not STREAMING.HAS_MODEL_LOADED(info.prop1) do
+                    STREAMING.REQUEST_MODEL(info.prop1)
+                    coroutine.yield()
+                end
+                prop1 = OBJECT.CREATE_OBJECT(info.prop1, 0.0, 0.0, 0.0, true, true, true)
+                table.insert(spawned_entities, prop1)
+                ENTITY.ATTACH_ENTITY_TO_ENTITY(prop1, target, targetBone, info.posx, info.posy, info.posz, info.rotx, info.roty, info.rotz, false, false, false, false, 2, true, 1)
+                ENTITY.SET_ENTITY_AS_NO_LONGER_NEEDED(prop1)
+            end
+            while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict) do
+                STREAMING.REQUEST_ANIM_DICT(info.dict)
+                coroutine.yield()
+            end
+            TASK.TASK_PLAY_ANIM(target, info.dict, info.anim, 4.0, -4.0, -1, flag, 1.0, false, false, false)
+            PED.SET_PED_CONFIG_FLAG(target, 179, true)
+            is_playing_anim = true
+        end)
+    elseif info.type == 2 then
+        cleanup()
+        script.run_in_fiber(function(type2)
+            while not STREAMING.HAS_NAMED_PTFX_ASSET_LOADED(info.ptfxdict) do
+                STREAMING.REQUEST_NAMED_PTFX_ASSET(info.ptfxdict)
+                coroutine.yield()
+            end
+            while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict) do
+                STREAMING.REQUEST_ANIM_DICT(info.dict)
+                coroutine.yield()
+            end
+            TASK.TASK_PLAY_ANIM(target, info.dict, info.anim, 4.0, -4.0, -1, flag, 0, false, false, false)
+            PED.SET_PED_CONFIG_FLAG(target, 179, true)
+            is_playing_anim = true
+            type2:sleep(info.ptfxdelay)
+            GRAPHICS.USE_PARTICLE_FX_ASSET(info.ptfxdict)
+            loopedFX = GRAPHICS.START_NETWORKED_PARTICLE_FX_LOOPED_ON_ENTITY_BONE(info.ptfxname, target, info.ptfxOffx, info.ptfxOffy, info.ptfxOffz, info.ptfxrotx, info.ptfxroty, info.ptfxrotz, targetBone, info.ptfxscale, false, false, false, 0, 0, 0, 0)
+        end)
+    elseif info.type == 3 then
+        cleanup()
+        script.run_in_fiber(function()
+            if not disableProps then
+                while not STREAMING.HAS_MODEL_LOADED(info.prop1) do
+                    STREAMING.REQUEST_MODEL(info.prop1)
+                    coroutine.yield()
+                end
+                prop1 = OBJECT.CREATE_OBJECT(info.prop1, targetCoords.x + targetForwardX /1.7, targetCoords.y + targetForwardY /1.7, targetCoords.z, true, true, false)
+                table.insert(spawned_entities, prop1)
+                ENTITY.SET_ENTITY_HEADING(prop1, targetHeading + info.rotz)
+                OBJECT.PLACE_OBJECT_ON_GROUND_PROPERLY(prop1)
+                ENTITY.SET_ENTITY_AS_NO_LONGER_NEEDED(prop1)
+            end
+            while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict) do
+                STREAMING.REQUEST_ANIM_DICT(info.dict)
+                coroutine.yield()
+            end
+            TASK.TASK_PLAY_ANIM(target, info.dict, info.anim, 4.0, -4.0, -1, flag, 1.0, false, false, false)
+            PED.SET_PED_CONFIG_FLAG(target, 179, true)
+            is_playing_anim = true
+        end)
+    elseif info.type == 4 then
+        cleanup()
+        script.run_in_fiber(function(type4)
+            if not disableProps then
+                while not STREAMING.HAS_MODEL_LOADED(info.prop1) do
+                    STREAMING.REQUEST_MODEL(info.prop1)
+                    coroutine.yield()
+                end
+                prop1 = OBJECT.CREATE_OBJECT(info.prop1, 0.0, 0.0, 0.0, true, true, false)
+                table.insert(spawned_entities, prop1)
+                ENTITY.SET_ENTITY_Coords(prop1, targetBoneCoords.x + info.posx, targetBoneCoords.y + info.posy, targetBoneCoords.z + info.posz)
+                type4:sleep(20)
+                OBJECT.PLACE_OBJECT_ON_GROUND_PROPERLY(prop1)
+                ENTITY.SET_ENTITY_COLLISION(prop1, info.propColl, info.propColl)
+                ENTITY.SET_ENTITY_AS_NO_LONGER_NEEDED(prop1)
+            end
+            while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict) do
+                STREAMING.REQUEST_ANIM_DICT(info.dict)
+                coroutine.yield()
+            end
+            TASK.TASK_PLAY_ANIM(target, info.dict, info.anim, 4.0, -4.0, -1, flag, 1.0, false, false, false)
+            PED.SET_PED_CONFIG_FLAG(target, 179, true)
+            is_playing_anim = true
+        end)
+    elseif info.type == 5 then
+        cleanup()
+        script.run_in_fiber(function(type5)
+            while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict) do
+                STREAMING.REQUEST_ANIM_DICT(info.dict)
+                coroutine.yield()
+            end
+            TASK.TASK_PLAY_ANIM(target, info.dict, info.anim, 4.0, -4.0, -1, flag, 0.0, false, false, false)
+            PED.SET_PED_CONFIG_FLAG(target, 179, true)
+            if not disableProps then
+                while not STREAMING.HAS_MODEL_LOADED(info.prop1) do
+                    STREAMING.REQUEST_MODEL(info.prop1)
+                    coroutine.yield()
+                end
+                prop1 = OBJECT.CREATE_OBJECT(info.prop1, 0.0, 0.0, 0.0, true, true, false)
+                table.insert(spawned_entities, prop1)
+                ENTITY.ATTACH_ENTITY_TO_ENTITY(prop1, target, targetBone, info.posx, info.posy, info.posz, info.rotx, info.roty, info.rotz, false, false, false, false, 2, true, 1)
+                ENTITY.SET_ENTITY_AS_NO_LONGER_NEEDED(prop1)
+                type5:sleep(50)
+                while not STREAMING.HAS_NAMED_PTFX_ASSET_LOADED(info.ptfxdict) do
+                    STREAMING.REQUEST_NAMED_PTFX_ASSET(info.ptfxdict)
+                    coroutine.yield()
+                end
+                type5:sleep(info.ptfxdelay)
+                GRAPHICS.USE_PARTICLE_FX_ASSET(info.ptfxdict)
+                loopedFX = GRAPHICS.START_NETWORKED_PARTICLE_FX_LOOPED_ON_ENTITY(info.ptfxname, prop1, info.ptfxOffx, info.ptfxOffy, info.ptfxOffz, info.ptfxrotx, info.ptfxroty, info.ptfxrotz, info.ptfxscale, false, false, false, 0, 0, 0, 0)
+            end
+            is_playing_anim = true
+        end)
+    elseif info.type == 6 then
+            cleanup()
+            script.run_in_fiber(function()
+                if not disableProps then
+                    while not STREAMING.HAS_MODEL_LOADED(info.prop1) do
+                        STREAMING.REQUEST_MODEL(info.prop1)
+                        coroutine.yield()
+                    end
+                    prop1 = OBJECT.CREATE_OBJECT(info.prop1, 0.0, 0.0, 0.0, true, true, false)
+                    table.insert(spawned_entities, prop1)
+                    ENTITY.ATTACH_ENTITY_TO_ENTITY(prop1, target, targetBone, info.posx, info.posy, info.posz, info.rotx, info.roty, info.rotz, false, false, false, false, 2, true, 1)
+                    while not STREAMING.HAS_MODEL_LOADED(info.prop2) do
+                        STREAMING.REQUEST_MODEL(info.prop2)
+                        coroutine.yield()
+                    end
+                    prop2 = OBJECT.CREATE_OBJECT(info.prop2, 0.0, 0.0, 0.0, true, true, false)
+                    table.insert(spawned_entities, prop2)
+                    ENTITY.ATTACH_ENTITY_TO_ENTITY(prop2, target, PED.GET_PED_BONE_INDEX(target, info.bone2), info.posx2, info.posy2, info.posz2, info.rotx2, info.roty2, info.rotz2, false, false, false, false, 2, true, 1)
+                    ENTITY.SET_ENTITY_AS_NO_LONGER_NEEDED(prop2)
+                end
+                while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict) do
+                    STREAMING.REQUEST_ANIM_DICT(info.dict)
+                    coroutine.yield()
+                end
+                TASK.TASK_PLAY_ANIM(target, info.dict, info.anim, 4.0, -4.0, -1, flag, 1.0, false, false, false)
+                PED.SET_PED_CONFIG_FLAG(target, 179, true)
+                is_playing_anim = true
+            end)
+    elseif info.type == 7 then
+        cleanup()
+        script.run_in_fiber(function()
+            if not disableProps then
+                while not STREAMING.HAS_MODEL_LOADED(info.pedHash) do
+                    STREAMING.REQUEST_MODEL(info.pedHash)
+                    coroutine.yield()
+                end
+                propPed = PED.CREATE_PED(info.pedType, info.pedHash, 0.0, 0.0, 0.0, 0.0, true, false)
+                ENTITY.ATTACH_ENTITY_TO_ENTITY(propPed, target, targetBone, info.posx, info.posy, info.posz, info.rotx, info.roty, info.rotz, false, true, false, true, 1, true, 1)
+                ENTITY.SET_ENTITY_INVINCIBLE(propPed, true)
+                table.insert(spawned_entities, propPed)
+                npcNetID = NETWORK.NETWORK_GET_NETWORK_ID_FROM_ENTITY(propPed)
+                RequestControl(propPed, npcNetID, 250)
+                entToNet(propPed, npcNetID)
+                while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict2) do
+                    STREAMING.REQUEST_ANIM_DICT(info.dict2)
+                    coroutine.yield()
+                end
+                TASK.TASK_PLAY_ANIM(propPed, info.dict2, info.anim2, 4.0, -4.0, -1, flag, 1.0, false, false, false)
+                PED.SET_PED_CONFIG_FLAG(propPed, 179, true)
+                PED.SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(propPed, true)
+            end
+            while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict) do
+                STREAMING.REQUEST_ANIM_DICT(info.dict)
+                coroutine.yield()
+            end
+            TASK.TASK_PLAY_ANIM(target, info.dict, info.anim, 4.0, -4.0, -1, flag, 1.0, false, false, false)
+            PED.SET_PED_CONFIG_FLAG(target, 179, true)
+            TASK.TASK_SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(propPed, true)
+            is_playing_anim = true
+        end)
+    else
+        cleanup()
+        script.run_in_fiber(function()
+            while not STREAMING.HAS_ANIM_DICT_LOADED(info.dict) do
+                STREAMING.REQUEST_ANIM_DICT(info.dict)
+                coroutine.yield()
+            end
+            TASK.TASK_PLAY_ANIM(target, info.dict, info.anim, 4.0, -4.0, -1, flag, 0.0, false, false, false)
+            PED.SET_PED_CONFIG_FLAG(target, 179, true)
+            is_playing_anim = true
+        end)
+    end
+end


### PR DESCRIPTION
- Renamed YimActions to _**Yim_Actions**_ hoping it would solve the conflict between the main script and the Extras implementation for users who have both installed at the same time (I don't think this fixes it though).
- Implemented the latest updates from the main script.
- Removed Harmless's config system from this version because it conflicted with Extra's config system. I couldn't make it work with gir489's config so I just disabled the feature for now.
- Slightly tweaked TokyoDrift. There was no need for a player ID loop, we can instead call `self.get_ped()` everytime we need the ID. Same thing was done for YimActions.